### PR TITLE
Add Relayout / Restyle, and bug fix ExtendTraces

### DIFF
--- a/Plotly.Blazor/Plotly.Blazor.csproj
+++ b/Plotly.Blazor/Plotly.Blazor.csproj
@@ -31,6 +31,7 @@ plotly.js is free and open source and you can view the source, report issues or 
     <PackageReference Include="Microsoft.AspNetCore.Components" Version="3.1.8" />
     <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="3.1.8" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="System.Text.Json" Version="4.7.2" />
   </ItemGroup>
 

--- a/Plotly.Blazor/PlotlyChart.razor
+++ b/Plotly.Blazor/PlotlyChart.razor
@@ -1,5 +1,6 @@
 ﻿@inject IJSRuntime JsRuntime
 @using Microsoft.JSInterop
+@using System.Text.Json;
 @using System.Collections
 @implements IDisposable
 
@@ -134,12 +135,71 @@
     }
 
     /// <summary>
-    ///     Updates the chart using the current properties.
+    ///     Updates the chart layout using the current properties.
     /// </summary>
     /// <returns>Task</returns>
     public async Task Relayout()
     {
         await JsRuntime.Relayout(objectReference);
+    }
+
+    /// <summary>
+    ///     Updates all the traces using the provided parameter
+    /// </summary>
+    /// <param name="trace">New trace parameter, create new object and assign only update value</param>
+    /// <returns>Task</returns>
+    public async Task Restyle(ITrace trace)
+    {
+        await Restyle(trace, Data?.Select((v, index) => index).ToArray());
+    }
+
+    /// <summary>
+    ///     Updates the specified trace using the provided parameter
+    /// </summary>
+    /// <param name="trace">New trace parameter, create new object and assign only update value</param>
+    /// <param name="index">Index of the trace. Use -1 e.g. to get the last one.</param>
+    /// <returns>Task</returns>
+    public async Task Restyle(ITrace trace, int index)
+    {
+        await Restyle(trace, new[] { index });
+    }
+
+    /// <summary>
+    ///     Updates the specified traces using the provided parameter
+    /// </summary>
+    /// <param name="trace">New trace parameter, create new object and assign only update value</param>
+    /// <param name="indizes">Indizes of the traces. Use -1 e.g. to get the last one.</param>
+    /// <returns>Task</returns>
+    public async Task Restyle(ITrace trace, IEnumerable<int> indizes)
+    {
+        if (indizes == null || !indizes.Any())
+        {
+            throw new ArgumentException("You must specifiy at least one index.");
+        }
+        if (trace == null)
+        {
+            throw new ArgumentNullException(nameof(trace));
+        }
+        List<int> absoluteIndizes = new List<int>();
+        foreach (var index in indizes)
+        {
+            int absoluteIndex = index < 0 ? Data.Count + index : index;
+            if (index > Data.Count - 1)
+            {
+                throw new ArgumentOutOfRangeException(nameof(index));
+            }
+            absoluteIndizes.Add(absoluteIndex);
+        }
+        var json = JsonSerializer.Serialize(trace?.PrepareJsInterop(PlotlyJsInterop.SerializerOptions));
+        //Console.WriteLine($"Restyling {json}");
+        foreach (var index in absoluteIndizes)
+        {
+            var currentTrace = Data[index];
+            //Console.WriteLine($"Restyle before [{index}] {JsonSerializer.Serialize(currentTrace, PlotlyJsInterop.SerializerOptions)}");
+            Newtonsoft.Json.JsonConvert.PopulateObject(json, currentTrace); // apply change to the existing object
+            //Console.WriteLine($"Restyle after [{index}] {JsonSerializer.Serialize(currentTrace, PlotlyJsInterop.SerializerOptions)}");
+        }
+        await JsRuntime.Restyle(objectReference, trace, absoluteIndizes.ToArray());
     }
 
     /// <summary>
@@ -314,7 +374,7 @@
         }
 
         // Add the data to the current traces
-        foreach (var index in indizesArr.Select((Value,Index) => new { Value, Index }))
+        foreach (var index in indizesArr.Select((Value, Index) => new { Value, Index }))
         {
             var currentTrace = index.Value < 0 ? Data[Data.Count + index.Value] : Data[index.Value];
             var traceType = currentTrace.GetType();

--- a/Plotly.Blazor/PlotlyChart.razor
+++ b/Plotly.Blazor/PlotlyChart.razor
@@ -191,13 +191,10 @@
             absoluteIndizes.Add(absoluteIndex);
         }
         var json = JsonSerializer.Serialize(trace?.PrepareJsInterop(PlotlyJsInterop.SerializerOptions));
-        //Console.WriteLine($"Restyling {json}");
         foreach (var index in absoluteIndizes)
         {
             var currentTrace = Data[index];
-            //Console.WriteLine($"Restyle before [{index}] {JsonSerializer.Serialize(currentTrace, PlotlyJsInterop.SerializerOptions)}");
             Newtonsoft.Json.JsonConvert.PopulateObject(json, currentTrace); // apply change to the existing object
-            //Console.WriteLine($"Restyle after [{index}] {JsonSerializer.Serialize(currentTrace, PlotlyJsInterop.SerializerOptions)}");
         }
         await JsRuntime.Restyle(objectReference, trace, absoluteIndizes.ToArray());
     }

--- a/Plotly.Blazor/PlotlyChart.razor
+++ b/Plotly.Blazor/PlotlyChart.razor
@@ -134,6 +134,15 @@
     }
 
     /// <summary>
+    ///     Updates the chart using the current properties.
+    /// </summary>
+    /// <returns>Task</returns>
+    public async Task Relayout()
+    {
+        await JsRuntime.Relayout(objectReference);
+    }
+
+    /// <summary>
     ///     Same as <see cref="React"/>.
     /// </summary>
     /// <returns>Task</returns>
@@ -305,15 +314,15 @@
         }
 
         // Add the data to the current traces
-        foreach (var index in indizesArr)
+        foreach (var index in indizesArr.Select((Value,Index) => new { Value, Index }))
         {
-            var currentTrace = index < 0 ? Data[^index] : Data[index];
+            var currentTrace = index.Value < 0 ? Data[Data.Count + index.Value] : Data[index.Value];
             var traceType = currentTrace.GetType();
 
             var xArray = x as IEnumerable<object>[] ?? x.ToArray();
             if (xArray.Length > 0)
             {
-                var currentXData = index < 0 ? xArray.ElementAt(xArray.Length - 1) : xArray.ElementAt(index);
+                var currentXData = xArray.ElementAt(index.Index);
                 var xData = currentXData as object[] ?? currentXData.ToArray();
                 if (xData.Length > 0)
                 {
@@ -324,7 +333,7 @@
             var yArray = y as IEnumerable<object>[] ?? y.ToArray();
             if (yArray.Length > 0)
             {
-                var currentYData = index < 0 ? yArray.ElementAt(yArray.Length + index) : yArray.ElementAt(index);
+                var currentYData = yArray.ElementAt(index.Index);
                 var yData = currentYData as object[] ?? currentYData.ToArray();
                 if (yData.Length > 0)
                 {

--- a/Plotly.Blazor/PlotlyJsInterop.cs
+++ b/Plotly.Blazor/PlotlyJsInterop.cs
@@ -148,9 +148,6 @@ namespace Plotly.Blazor
         public static async Task Restyle(this IJSRuntime jsRuntime,
             DotNetObjectReference<PlotlyChart> objectReference, ITrace trace, IEnumerable<int> indizes)
         {
-            //var data = trace?.PrepareJsInterop(SerializerOptions);
-            //Console.WriteLine($"Restyle [{string.Join(", ", indizes.ToArray())}] {JsonSerializer.Serialize(data)}");
-            //JsonSerializer.pop
             await jsRuntime.InvokeVoidAsync($"{PlotlyInterop}.restyle", objectReference.Value.Id, trace?.PrepareJsInterop(SerializerOptions), indizes);
         }
 

--- a/Plotly.Blazor/PlotlyJsInterop.cs
+++ b/Plotly.Blazor/PlotlyJsInterop.cs
@@ -124,5 +124,19 @@ namespace Plotly.Blazor
         {
             await jsRuntime.InvokeVoidAsync($"{PlotlyInterop}.purge", objectReference.Value.Id);
         }
+
+        /// <summary>
+        ///     An efficient means of updating the layout object of an existing plot.
+        /// </summary>
+        /// <param name="jsRuntime">The js runtime.</param>
+        /// <param name="objectReference">The object reference.</param>
+        public static async Task Relayout(this IJSRuntime jsRuntime, DotNetObjectReference<PlotlyChart> objectReference)
+        {
+            await jsRuntime.InvokeVoidAsync($"{PlotlyInterop}.relayout",
+                objectReference.Value.Id,
+                objectReference.Value.Layout?.PrepareJsInterop(SerializerOptions));
+        }
+
+        
     }
 }

--- a/Plotly.Blazor/PlotlyJsInterop.cs
+++ b/Plotly.Blazor/PlotlyJsInterop.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.Json;
@@ -16,7 +17,7 @@ namespace Plotly.Blazor
         // Should be fixed in future blazor wasm releases
         private const string PlotlyInterop = "plotlyInterop";
 
-        private static readonly JsonSerializerOptions SerializerOptions = new JsonSerializerOptions
+        internal static readonly JsonSerializerOptions SerializerOptions = new JsonSerializerOptions
         {
             PropertyNamingPolicy = null,
             IgnoreNullValues = true,
@@ -137,6 +138,24 @@ namespace Plotly.Blazor
                 objectReference.Value.Layout?.PrepareJsInterop(SerializerOptions));
         }
 
-        
+        /// <summary>
+        ///     Can be used to add data to an existing trace.
+        /// </summary>
+        /// <param name="jsRuntime">The js runtime.</param>
+        /// <param name="objectReference">The object reference.</param>
+        /// <param name="trace">The new trace parameter</param>
+        /// <param name="indizes">Indizes.</param>
+        public static async Task Restyle(this IJSRuntime jsRuntime,
+            DotNetObjectReference<PlotlyChart> objectReference, ITrace trace, IEnumerable<int> indizes)
+        {
+            //var data = trace?.PrepareJsInterop(SerializerOptions);
+            //Console.WriteLine($"Restyle [{string.Join(", ", indizes.ToArray())}] {JsonSerializer.Serialize(data)}");
+            //JsonSerializer.pop
+            await jsRuntime.InvokeVoidAsync($"{PlotlyInterop}.restyle", objectReference.Value.Id, trace?.PrepareJsInterop(SerializerOptions), indizes);
+        }
+
+
+
+
     }
 }

--- a/Plotly.Blazor/wwwroot/plotly-interop.js
+++ b/Plotly.Blazor/wwwroot/plotly-interop.js
@@ -41,5 +41,7 @@
     relayout: function (id, layout = {} ) {
         window.Plotly.relayout(id, layout);
     },
-
+    restyle: function (id, data, indizes) {
+        window.Plotly.restyle(id, data, indizes);
+    }
 }

--- a/Plotly.Blazor/wwwroot/plotly-interop.js
+++ b/Plotly.Blazor/wwwroot/plotly-interop.js
@@ -37,5 +37,9 @@
     },
     purge: function (id) {
         window.Plotly.purge(id);
-    }
+    },
+    relayout: function (id, layout = {} ) {
+        window.Plotly.relayout(id, layout);
+    },
+
 }


### PR DESCRIPTION
ExtendTraces was buggy if there was more than 1 Trace in the chart, I fixed it.
I add the Relayout command.
I add the Restyle command, Restyle can be used like this:
                        ScatterGl updateScatterChart = new ScatterGl();
                        updateScatterChart.YAxis = "y2";
                        await plotlyChart.Restyle(updateScatterChart, 0);
the change is applied back to the ITrace object with (line 197 in file PlotlyChart.razor)
Newtonsoft.Json.JsonConvert.PopulateObject(json, currentTrace); // apply change to the existing object

