### PR TITLE
Updated xml comments by regenerating from latest schema

### DIFF
--- a/Plotly.Blazor/LayoutLib/LegendLib/ItemClickEnum.cs
+++ b/Plotly.Blazor/LayoutLib/LegendLib/ItemClickEnum.cs
@@ -11,7 +11,7 @@ namespace Plotly.Blazor.LayoutLib.LegendLib
     /// <summary>
     ///     Determines the behavior on legend item click. <c>toggle</c> toggles the
     ///     visibility of the item clicked on the graph. <c>toggleothers</c> makes the
-    ///     clicked item the sole visible item on the graph. <c>false</c> disable legend
+    ///     clicked item the sole visible item on the graph. <c>false</c> disables legend
     ///     item click interactions.
     /// </summary>
     [System.CodeDom.Compiler.GeneratedCode("Plotly.Blazor.Generator", "1.0.0.0")]

--- a/Plotly.Blazor/LayoutLib/LegendLib/ItemDoubleClickEnum.cs
+++ b/Plotly.Blazor/LayoutLib/LegendLib/ItemDoubleClickEnum.cs
@@ -11,7 +11,7 @@ namespace Plotly.Blazor.LayoutLib.LegendLib
     /// <summary>
     ///     Determines the behavior on legend item double-click. <c>toggle</c> toggles
     ///     the visibility of the item clicked on the graph. <c>toggleothers</c> makes
-    ///     the clicked item the sole visible item on the graph. <c>false</c> disable
+    ///     the clicked item the sole visible item on the graph. <c>false</c> disables
     ///     legend item double-click interactions.
     /// </summary>
     [System.CodeDom.Compiler.GeneratedCode("Plotly.Blazor.Generator", "1.0.0.0")]

--- a/Plotly.Blazor/LayoutLib/MapBoxLib/LayerLib/Line.cs
+++ b/Plotly.Blazor/LayoutLib/MapBoxLib/LayerLib/Line.cs
@@ -27,7 +27,7 @@ namespace Plotly.Blazor.LayoutLib.MapBoxLib.LayerLib
         public IList<object> Dash { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  dash .
+        ///     Sets the source reference on Chart Studio Cloud for <c>dash</c>.
         /// </summary>
         [JsonPropertyName(@"dashsrc")]
         public string DashSrc { get; set;} 

--- a/Plotly.Blazor/LayoutLib/ModeBar.cs
+++ b/Plotly.Blazor/LayoutLib/ModeBar.cs
@@ -50,7 +50,7 @@ namespace Plotly.Blazor.LayoutLib
         public IList<string> AddArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  add .
+        ///     Sets the source reference on Chart Studio Cloud for <c>add</c>.
         /// </summary>
         [JsonPropertyName(@"addsrc")]
         public string AddSrc { get; set;} 
@@ -113,7 +113,7 @@ namespace Plotly.Blazor.LayoutLib
         public IList<string> RemoveArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  remove .
+        ///     Sets the source reference on Chart Studio Cloud for <c>remove</c>.
         /// </summary>
         [JsonPropertyName(@"removesrc")]
         public string RemoveSrc { get; set;} 

--- a/Plotly.Blazor/LayoutLib/SceneLib/XAxis.cs
+++ b/Plotly.Blazor/LayoutLib/SceneLib/XAxis.cs
@@ -58,7 +58,7 @@ namespace Plotly.Blazor.LayoutLib.SceneLib
         public IList<object> CategoryArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  categoryarray .
+        ///     Sets the source reference on Chart Studio Cloud for <c>categoryarray</c>.
         /// </summary>
         [JsonPropertyName(@"categoryarraysrc")]
         public string CategoryArraySrc { get; set;} 
@@ -385,7 +385,7 @@ namespace Plotly.Blazor.LayoutLib.SceneLib
         public IList<object> TickText { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  ticktext .
+        ///     Sets the source reference on Chart Studio Cloud for <c>ticktext</c>.
         /// </summary>
         [JsonPropertyName(@"ticktextsrc")]
         public string TickTextSrc { get; set;} 
@@ -398,7 +398,7 @@ namespace Plotly.Blazor.LayoutLib.SceneLib
         public IList<object> TickVals { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  tickvals .
+        ///     Sets the source reference on Chart Studio Cloud for <c>tickvals</c>.
         /// </summary>
         [JsonPropertyName(@"tickvalssrc")]
         public string TickValsSrc { get; set;} 

--- a/Plotly.Blazor/LayoutLib/SceneLib/YAxis.cs
+++ b/Plotly.Blazor/LayoutLib/SceneLib/YAxis.cs
@@ -58,7 +58,7 @@ namespace Plotly.Blazor.LayoutLib.SceneLib
         public IList<object> CategoryArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  categoryarray .
+        ///     Sets the source reference on Chart Studio Cloud for <c>categoryarray</c>.
         /// </summary>
         [JsonPropertyName(@"categoryarraysrc")]
         public string CategoryArraySrc { get; set;} 
@@ -385,7 +385,7 @@ namespace Plotly.Blazor.LayoutLib.SceneLib
         public IList<object> TickText { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  ticktext .
+        ///     Sets the source reference on Chart Studio Cloud for <c>ticktext</c>.
         /// </summary>
         [JsonPropertyName(@"ticktextsrc")]
         public string TickTextSrc { get; set;} 
@@ -398,7 +398,7 @@ namespace Plotly.Blazor.LayoutLib.SceneLib
         public IList<object> TickVals { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  tickvals .
+        ///     Sets the source reference on Chart Studio Cloud for <c>tickvals</c>.
         /// </summary>
         [JsonPropertyName(@"tickvalssrc")]
         public string TickValsSrc { get; set;} 

--- a/Plotly.Blazor/LayoutLib/SceneLib/ZAxis.cs
+++ b/Plotly.Blazor/LayoutLib/SceneLib/ZAxis.cs
@@ -58,7 +58,7 @@ namespace Plotly.Blazor.LayoutLib.SceneLib
         public IList<object> CategoryArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  categoryarray .
+        ///     Sets the source reference on Chart Studio Cloud for <c>categoryarray</c>.
         /// </summary>
         [JsonPropertyName(@"categoryarraysrc")]
         public string CategoryArraySrc { get; set;} 
@@ -385,7 +385,7 @@ namespace Plotly.Blazor.LayoutLib.SceneLib
         public IList<object> TickText { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  ticktext .
+        ///     Sets the source reference on Chart Studio Cloud for <c>ticktext</c>.
         /// </summary>
         [JsonPropertyName(@"ticktextsrc")]
         public string TickTextSrc { get; set;} 
@@ -398,7 +398,7 @@ namespace Plotly.Blazor.LayoutLib.SceneLib
         public IList<object> TickVals { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  tickvals .
+        ///     Sets the source reference on Chart Studio Cloud for <c>tickvals</c>.
         /// </summary>
         [JsonPropertyName(@"tickvalssrc")]
         public string TickValsSrc { get; set;} 

--- a/Plotly.Blazor/Traces/Bar.cs
+++ b/Plotly.Blazor/Traces/Bar.cs
@@ -51,7 +51,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> BaseArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  base .
+        ///     Sets the source reference on Chart Studio Cloud for <c>base</c>.
         /// </summary>
         [JsonPropertyName(@"basesrc")]
         public string BaseSrc { get; set;} 
@@ -80,7 +80,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> CustomData { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  customdata .
+        ///     Sets the source reference on Chart Studio Cloud for <c>customdata</c>.
         /// </summary>
         [JsonPropertyName(@"customdatasrc")]
         public string CustomDataSrc { get; set;} 
@@ -127,7 +127,7 @@ namespace Plotly.Blazor.Traces
         public IList<Plotly.Blazor.Traces.BarLib.HoverInfoFlag?> HoverInfoArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  hoverinfo .
+        ///     Sets the source reference on Chart Studio Cloud for <c>hoverinfo</c>.
         /// </summary>
         [JsonPropertyName(@"hoverinfosrc")]
         public string HoverInfoSrc { get; set;} 
@@ -188,7 +188,7 @@ namespace Plotly.Blazor.Traces
         public IList<string> HoverTemplateArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  hovertemplate .
+        ///     Sets the source reference on Chart Studio Cloud for <c>hovertemplate</c>.
         /// </summary>
         [JsonPropertyName(@"hovertemplatesrc")]
         public string HoverTemplateSrc { get; set;} 
@@ -213,7 +213,7 @@ namespace Plotly.Blazor.Traces
         public IList<string> HoverTextArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  hovertext .
+        ///     Sets the source reference on Chart Studio Cloud for <c>hovertext</c>.
         /// </summary>
         [JsonPropertyName(@"hovertextsrc")]
         public string HoverTextSrc { get; set;} 
@@ -227,7 +227,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> Ids { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  ids .
+        ///     Sets the source reference on Chart Studio Cloud for <c>ids</c>.
         /// </summary>
         [JsonPropertyName(@"idssrc")]
         public string IdsSrc { get; set;} 
@@ -304,7 +304,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> MetaArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  meta .
+        ///     Sets the source reference on Chart Studio Cloud for <c>meta</c>.
         /// </summary>
         [JsonPropertyName(@"metasrc")]
         public string MetaSrc { get; set;} 
@@ -341,7 +341,7 @@ namespace Plotly.Blazor.Traces
         public string OffsetGroup { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  offset .
+        ///     Sets the source reference on Chart Studio Cloud for <c>offset</c>.
         /// </summary>
         [JsonPropertyName(@"offsetsrc")]
         public string OffsetSrc { get; set;} 
@@ -455,13 +455,13 @@ namespace Plotly.Blazor.Traces
         public IList<Plotly.Blazor.Traces.BarLib.TextPositionEnum?> TextPositionArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  textposition .
+        ///     Sets the source reference on Chart Studio Cloud for <c>textposition</c>.
         /// </summary>
         [JsonPropertyName(@"textpositionsrc")]
         public string TextPositionSrc { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  text .
+        ///     Sets the source reference on Chart Studio Cloud for <c>text</c>.
         /// </summary>
         [JsonPropertyName(@"textsrc")]
         public string TextSrc { get; set;} 
@@ -500,7 +500,7 @@ namespace Plotly.Blazor.Traces
         public IList<string> TextTemplateArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  texttemplate .
+        ///     Sets the source reference on Chart Studio Cloud for <c>texttemplate</c>.
         /// </summary>
         [JsonPropertyName(@"texttemplatesrc")]
         public string TextTemplateSrc { get; set;} 
@@ -563,7 +563,7 @@ namespace Plotly.Blazor.Traces
         public IList<decimal?> WidthArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  width .
+        ///     Sets the source reference on Chart Studio Cloud for <c>width</c>.
         /// </summary>
         [JsonPropertyName(@"widthsrc")]
         public string WidthSrc { get; set;} 
@@ -634,7 +634,7 @@ namespace Plotly.Blazor.Traces
         public Plotly.Blazor.Traces.BarLib.XPeriodAlignmentEnum? XPeriodAlignment { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  x .
+        ///     Sets the source reference on Chart Studio Cloud for <c>x</c>.
         /// </summary>
         [JsonPropertyName(@"xsrc")]
         public string XSrc { get; set;} 
@@ -705,7 +705,7 @@ namespace Plotly.Blazor.Traces
         public Plotly.Blazor.Traces.BarLib.YPeriodAlignmentEnum? YPeriodAlignment { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  y .
+        ///     Sets the source reference on Chart Studio Cloud for <c>y</c>.
         /// </summary>
         [JsonPropertyName(@"ysrc")]
         public string YSrc { get; set;} 

--- a/Plotly.Blazor/Traces/BarLib/ErrorX.cs
+++ b/Plotly.Blazor/Traces/BarLib/ErrorX.cs
@@ -35,13 +35,13 @@ namespace Plotly.Blazor.Traces.BarLib
         public IList<object> ArrayMinus { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  arrayminus .
+        ///     Sets the source reference on Chart Studio Cloud for <c>arrayminus</c>.
         /// </summary>
         [JsonPropertyName(@"arrayminussrc")]
         public string ArrayMinusSrc { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  array .
+        ///     Sets the source reference on Chart Studio Cloud for <c>array</c>.
         /// </summary>
         [JsonPropertyName(@"arraysrc")]
         public string ArraySrc { get; set;} 

--- a/Plotly.Blazor/Traces/BarLib/ErrorY.cs
+++ b/Plotly.Blazor/Traces/BarLib/ErrorY.cs
@@ -35,13 +35,13 @@ namespace Plotly.Blazor.Traces.BarLib
         public IList<object> ArrayMinus { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  arrayminus .
+        ///     Sets the source reference on Chart Studio Cloud for <c>arrayminus</c>.
         /// </summary>
         [JsonPropertyName(@"arrayminussrc")]
         public string ArrayMinusSrc { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  array .
+        ///     Sets the source reference on Chart Studio Cloud for <c>array</c>.
         /// </summary>
         [JsonPropertyName(@"arraysrc")]
         public string ArraySrc { get; set;} 

--- a/Plotly.Blazor/Traces/BarLib/HoverLabel.cs
+++ b/Plotly.Blazor/Traces/BarLib/HoverLabel.cs
@@ -36,7 +36,7 @@ namespace Plotly.Blazor.Traces.BarLib
         public IList<Plotly.Blazor.Traces.BarLib.HoverLabelLib.AlignEnum?> AlignArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  align .
+        ///     Sets the source reference on Chart Studio Cloud for <c>align</c>.
         /// </summary>
         [JsonPropertyName(@"alignsrc")]
         public string AlignSrc { get; set;} 
@@ -55,7 +55,7 @@ namespace Plotly.Blazor.Traces.BarLib
         public IList<object> BgColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  bgcolor .
+        ///     Sets the source reference on Chart Studio Cloud for <c>bgcolor</c>.
         /// </summary>
         [JsonPropertyName(@"bgcolorsrc")]
         public string BgColorSrc { get; set;} 
@@ -74,7 +74,7 @@ namespace Plotly.Blazor.Traces.BarLib
         public IList<object> BorderColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  bordercolor .
+        ///     Sets the source reference on Chart Studio Cloud for <c>bordercolor</c>.
         /// </summary>
         [JsonPropertyName(@"bordercolorsrc")]
         public string BorderColorSrc { get; set;} 
@@ -107,7 +107,7 @@ namespace Plotly.Blazor.Traces.BarLib
         public IList<int?> NameLengthArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  namelength .
+        ///     Sets the source reference on Chart Studio Cloud for <c>namelength</c>.
         /// </summary>
         [JsonPropertyName(@"namelengthsrc")]
         public string NameLengthSrc { get; set;} 

--- a/Plotly.Blazor/Traces/BarLib/HoverLabelLib/Font.cs
+++ b/Plotly.Blazor/Traces/BarLib/HoverLabelLib/Font.cs
@@ -34,7 +34,7 @@ namespace Plotly.Blazor.Traces.BarLib.HoverLabelLib
         public IList<object> ColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  color .
+        ///     Sets the source reference on Chart Studio Cloud for <c>color</c>.
         /// </summary>
         [JsonPropertyName(@"colorsrc")]
         public string ColorSrc { get; set;} 
@@ -73,7 +73,7 @@ namespace Plotly.Blazor.Traces.BarLib.HoverLabelLib
         public IList<string> FamilyArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  family .
+        ///     Sets the source reference on Chart Studio Cloud for <c>family</c>.
         /// </summary>
         [JsonPropertyName(@"familysrc")]
         public string FamilySrc { get; set;} 
@@ -92,7 +92,7 @@ namespace Plotly.Blazor.Traces.BarLib.HoverLabelLib
         public IList<decimal?> SizeArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  size .
+        ///     Sets the source reference on Chart Studio Cloud for <c>size</c>.
         /// </summary>
         [JsonPropertyName(@"sizesrc")]
         public string SizeSrc { get; set;} 

--- a/Plotly.Blazor/Traces/BarLib/InsideTextFont.cs
+++ b/Plotly.Blazor/Traces/BarLib/InsideTextFont.cs
@@ -34,7 +34,7 @@ namespace Plotly.Blazor.Traces.BarLib
         public IList<object> ColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  color .
+        ///     Sets the source reference on Chart Studio Cloud for <c>color</c>.
         /// </summary>
         [JsonPropertyName(@"colorsrc")]
         public string ColorSrc { get; set;} 
@@ -73,7 +73,7 @@ namespace Plotly.Blazor.Traces.BarLib
         public IList<string> FamilyArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  family .
+        ///     Sets the source reference on Chart Studio Cloud for <c>family</c>.
         /// </summary>
         [JsonPropertyName(@"familysrc")]
         public string FamilySrc { get; set;} 
@@ -92,7 +92,7 @@ namespace Plotly.Blazor.Traces.BarLib
         public IList<decimal?> SizeArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  size .
+        ///     Sets the source reference on Chart Studio Cloud for <c>size</c>.
         /// </summary>
         [JsonPropertyName(@"sizesrc")]
         public string SizeSrc { get; set;} 

--- a/Plotly.Blazor/Traces/BarLib/Marker.cs
+++ b/Plotly.Blazor/Traces/BarLib/Marker.cs
@@ -114,7 +114,7 @@ namespace Plotly.Blazor.Traces.BarLib
         public object ColorScale { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  color .
+        ///     Sets the source reference on Chart Studio Cloud for <c>color</c>.
         /// </summary>
         [JsonPropertyName(@"colorsrc")]
         public string ColorSrc { get; set;} 
@@ -139,7 +139,7 @@ namespace Plotly.Blazor.Traces.BarLib
         public IList<decimal?> OpacityArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  opacity .
+        ///     Sets the source reference on Chart Studio Cloud for <c>opacity</c>.
         /// </summary>
         [JsonPropertyName(@"opacitysrc")]
         public string OpacitySrc { get; set;} 

--- a/Plotly.Blazor/Traces/BarLib/MarkerLib/Line.cs
+++ b/Plotly.Blazor/Traces/BarLib/MarkerLib/Line.cs
@@ -110,7 +110,7 @@ namespace Plotly.Blazor.Traces.BarLib.MarkerLib
         public object ColorScale { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  color .
+        ///     Sets the source reference on Chart Studio Cloud for <c>color</c>.
         /// </summary>
         [JsonPropertyName(@"colorsrc")]
         public string ColorSrc { get; set;} 
@@ -138,7 +138,7 @@ namespace Plotly.Blazor.Traces.BarLib.MarkerLib
         public IList<decimal?> WidthArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  width .
+        ///     Sets the source reference on Chart Studio Cloud for <c>width</c>.
         /// </summary>
         [JsonPropertyName(@"widthsrc")]
         public string WidthSrc { get; set;} 

--- a/Plotly.Blazor/Traces/BarLib/MarkerLib/Pattern.cs
+++ b/Plotly.Blazor/Traces/BarLib/MarkerLib/Pattern.cs
@@ -38,7 +38,7 @@ namespace Plotly.Blazor.Traces.BarLib.MarkerLib
         public IList<object> BgColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  bgcolor .
+        ///     Sets the source reference on Chart Studio Cloud for <c>bgcolor</c>.
         /// </summary>
         [JsonPropertyName(@"bgcolorsrc")]
         public string BgColorSrc { get; set;} 
@@ -63,7 +63,7 @@ namespace Plotly.Blazor.Traces.BarLib.MarkerLib
         public IList<object> FgColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  fgcolor .
+        ///     Sets the source reference on Chart Studio Cloud for <c>fgcolor</c>.
         /// </summary>
         [JsonPropertyName(@"fgcolorsrc")]
         public string FgColorSrc { get; set;} 
@@ -98,7 +98,7 @@ namespace Plotly.Blazor.Traces.BarLib.MarkerLib
         public IList<Plotly.Blazor.Traces.BarLib.MarkerLib.PatternLib.ShapeEnum?> ShapeArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  shape .
+        ///     Sets the source reference on Chart Studio Cloud for <c>shape</c>.
         /// </summary>
         [JsonPropertyName(@"shapesrc")]
         public string ShapeSrc { get; set;} 
@@ -119,7 +119,7 @@ namespace Plotly.Blazor.Traces.BarLib.MarkerLib
         public IList<decimal?> SizeArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  size .
+        ///     Sets the source reference on Chart Studio Cloud for <c>size</c>.
         /// </summary>
         [JsonPropertyName(@"sizesrc")]
         public string SizeSrc { get; set;} 
@@ -144,7 +144,7 @@ namespace Plotly.Blazor.Traces.BarLib.MarkerLib
         public IList<decimal?> SolidityArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  solidity .
+        ///     Sets the source reference on Chart Studio Cloud for <c>solidity</c>.
         /// </summary>
         [JsonPropertyName(@"soliditysrc")]
         public string SoliditySrc { get; set;} 

--- a/Plotly.Blazor/Traces/BarLib/OutsideTextFont.cs
+++ b/Plotly.Blazor/Traces/BarLib/OutsideTextFont.cs
@@ -34,7 +34,7 @@ namespace Plotly.Blazor.Traces.BarLib
         public IList<object> ColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  color .
+        ///     Sets the source reference on Chart Studio Cloud for <c>color</c>.
         /// </summary>
         [JsonPropertyName(@"colorsrc")]
         public string ColorSrc { get; set;} 
@@ -73,7 +73,7 @@ namespace Plotly.Blazor.Traces.BarLib
         public IList<string> FamilyArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  family .
+        ///     Sets the source reference on Chart Studio Cloud for <c>family</c>.
         /// </summary>
         [JsonPropertyName(@"familysrc")]
         public string FamilySrc { get; set;} 
@@ -92,7 +92,7 @@ namespace Plotly.Blazor.Traces.BarLib
         public IList<decimal?> SizeArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  size .
+        ///     Sets the source reference on Chart Studio Cloud for <c>size</c>.
         /// </summary>
         [JsonPropertyName(@"sizesrc")]
         public string SizeSrc { get; set;} 

--- a/Plotly.Blazor/Traces/BarLib/TextFont.cs
+++ b/Plotly.Blazor/Traces/BarLib/TextFont.cs
@@ -34,7 +34,7 @@ namespace Plotly.Blazor.Traces.BarLib
         public IList<object> ColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  color .
+        ///     Sets the source reference on Chart Studio Cloud for <c>color</c>.
         /// </summary>
         [JsonPropertyName(@"colorsrc")]
         public string ColorSrc { get; set;} 
@@ -73,7 +73,7 @@ namespace Plotly.Blazor.Traces.BarLib
         public IList<string> FamilyArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  family .
+        ///     Sets the source reference on Chart Studio Cloud for <c>family</c>.
         /// </summary>
         [JsonPropertyName(@"familysrc")]
         public string FamilySrc { get; set;} 
@@ -92,7 +92,7 @@ namespace Plotly.Blazor.Traces.BarLib
         public IList<decimal?> SizeArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  size .
+        ///     Sets the source reference on Chart Studio Cloud for <c>size</c>.
         /// </summary>
         [JsonPropertyName(@"sizesrc")]
         public string SizeSrc { get; set;} 

--- a/Plotly.Blazor/Traces/BarPolar.cs
+++ b/Plotly.Blazor/Traces/BarPolar.cs
@@ -43,7 +43,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> BaseArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  base .
+        ///     Sets the source reference on Chart Studio Cloud for <c>base</c>.
         /// </summary>
         [JsonPropertyName(@"basesrc")]
         public string BaseSrc { get; set;} 
@@ -57,7 +57,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> CustomData { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  customdata .
+        ///     Sets the source reference on Chart Studio Cloud for <c>customdata</c>.
         /// </summary>
         [JsonPropertyName(@"customdatasrc")]
         public string CustomDataSrc { get; set;} 
@@ -93,7 +93,7 @@ namespace Plotly.Blazor.Traces
         public IList<Plotly.Blazor.Traces.BarPolarLib.HoverInfoFlag?> HoverInfoArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  hoverinfo .
+        ///     Sets the source reference on Chart Studio Cloud for <c>hoverinfo</c>.
         /// </summary>
         [JsonPropertyName(@"hoverinfosrc")]
         public string HoverInfoSrc { get; set;} 
@@ -154,7 +154,7 @@ namespace Plotly.Blazor.Traces
         public IList<string> HoverTemplateArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  hovertemplate .
+        ///     Sets the source reference on Chart Studio Cloud for <c>hovertemplate</c>.
         /// </summary>
         [JsonPropertyName(@"hovertemplatesrc")]
         public string HoverTemplateSrc { get; set;} 
@@ -173,7 +173,7 @@ namespace Plotly.Blazor.Traces
         public IList<string> HoverTextArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  hovertext .
+        ///     Sets the source reference on Chart Studio Cloud for <c>hovertext</c>.
         /// </summary>
         [JsonPropertyName(@"hovertextsrc")]
         public string HoverTextSrc { get; set;} 
@@ -187,7 +187,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> Ids { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  ids .
+        ///     Sets the source reference on Chart Studio Cloud for <c>ids</c>.
         /// </summary>
         [JsonPropertyName(@"idssrc")]
         public string IdsSrc { get; set;} 
@@ -251,7 +251,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> MetaArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  meta .
+        ///     Sets the source reference on Chart Studio Cloud for <c>meta</c>.
         /// </summary>
         [JsonPropertyName(@"metasrc")]
         public string MetaSrc { get; set;} 
@@ -278,7 +278,7 @@ namespace Plotly.Blazor.Traces
         public IList<decimal?> OffsetArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  offset .
+        ///     Sets the source reference on Chart Studio Cloud for <c>offset</c>.
         /// </summary>
         [JsonPropertyName(@"offsetsrc")]
         public string OffsetSrc { get; set;} 
@@ -303,7 +303,7 @@ namespace Plotly.Blazor.Traces
         public object R0 { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  r .
+        ///     Sets the source reference on Chart Studio Cloud for <c>r</c>.
         /// </summary>
         [JsonPropertyName(@"rsrc")]
         public string RSrc { get; set;} 
@@ -363,7 +363,7 @@ namespace Plotly.Blazor.Traces
         public IList<string> TextArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  text .
+        ///     Sets the source reference on Chart Studio Cloud for <c>text</c>.
         /// </summary>
         [JsonPropertyName(@"textsrc")]
         public string TextSrc { get; set;} 
@@ -383,7 +383,7 @@ namespace Plotly.Blazor.Traces
         public object Theta0 { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  theta .
+        ///     Sets the source reference on Chart Studio Cloud for <c>theta</c>.
         /// </summary>
         [JsonPropertyName(@"thetasrc")]
         public string ThetaSrc { get; set;} 
@@ -453,7 +453,7 @@ namespace Plotly.Blazor.Traces
         public IList<decimal?> WidthArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  width .
+        ///     Sets the source reference on Chart Studio Cloud for <c>width</c>.
         /// </summary>
         [JsonPropertyName(@"widthsrc")]
         public string WidthSrc { get; set;} 

--- a/Plotly.Blazor/Traces/BarPolarLib/HoverLabel.cs
+++ b/Plotly.Blazor/Traces/BarPolarLib/HoverLabel.cs
@@ -36,7 +36,7 @@ namespace Plotly.Blazor.Traces.BarPolarLib
         public IList<Plotly.Blazor.Traces.BarPolarLib.HoverLabelLib.AlignEnum?> AlignArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  align .
+        ///     Sets the source reference on Chart Studio Cloud for <c>align</c>.
         /// </summary>
         [JsonPropertyName(@"alignsrc")]
         public string AlignSrc { get; set;} 
@@ -55,7 +55,7 @@ namespace Plotly.Blazor.Traces.BarPolarLib
         public IList<object> BgColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  bgcolor .
+        ///     Sets the source reference on Chart Studio Cloud for <c>bgcolor</c>.
         /// </summary>
         [JsonPropertyName(@"bgcolorsrc")]
         public string BgColorSrc { get; set;} 
@@ -74,7 +74,7 @@ namespace Plotly.Blazor.Traces.BarPolarLib
         public IList<object> BorderColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  bordercolor .
+        ///     Sets the source reference on Chart Studio Cloud for <c>bordercolor</c>.
         /// </summary>
         [JsonPropertyName(@"bordercolorsrc")]
         public string BorderColorSrc { get; set;} 
@@ -107,7 +107,7 @@ namespace Plotly.Blazor.Traces.BarPolarLib
         public IList<int?> NameLengthArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  namelength .
+        ///     Sets the source reference on Chart Studio Cloud for <c>namelength</c>.
         /// </summary>
         [JsonPropertyName(@"namelengthsrc")]
         public string NameLengthSrc { get; set;} 

--- a/Plotly.Blazor/Traces/BarPolarLib/HoverLabelLib/Font.cs
+++ b/Plotly.Blazor/Traces/BarPolarLib/HoverLabelLib/Font.cs
@@ -34,7 +34,7 @@ namespace Plotly.Blazor.Traces.BarPolarLib.HoverLabelLib
         public IList<object> ColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  color .
+        ///     Sets the source reference on Chart Studio Cloud for <c>color</c>.
         /// </summary>
         [JsonPropertyName(@"colorsrc")]
         public string ColorSrc { get; set;} 
@@ -73,7 +73,7 @@ namespace Plotly.Blazor.Traces.BarPolarLib.HoverLabelLib
         public IList<string> FamilyArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  family .
+        ///     Sets the source reference on Chart Studio Cloud for <c>family</c>.
         /// </summary>
         [JsonPropertyName(@"familysrc")]
         public string FamilySrc { get; set;} 
@@ -92,7 +92,7 @@ namespace Plotly.Blazor.Traces.BarPolarLib.HoverLabelLib
         public IList<decimal?> SizeArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  size .
+        ///     Sets the source reference on Chart Studio Cloud for <c>size</c>.
         /// </summary>
         [JsonPropertyName(@"sizesrc")]
         public string SizeSrc { get; set;} 

--- a/Plotly.Blazor/Traces/BarPolarLib/Marker.cs
+++ b/Plotly.Blazor/Traces/BarPolarLib/Marker.cs
@@ -114,7 +114,7 @@ namespace Plotly.Blazor.Traces.BarPolarLib
         public object ColorScale { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  color .
+        ///     Sets the source reference on Chart Studio Cloud for <c>color</c>.
         /// </summary>
         [JsonPropertyName(@"colorsrc")]
         public string ColorSrc { get; set;} 
@@ -139,7 +139,7 @@ namespace Plotly.Blazor.Traces.BarPolarLib
         public IList<decimal?> OpacityArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  opacity .
+        ///     Sets the source reference on Chart Studio Cloud for <c>opacity</c>.
         /// </summary>
         [JsonPropertyName(@"opacitysrc")]
         public string OpacitySrc { get; set;} 

--- a/Plotly.Blazor/Traces/BarPolarLib/MarkerLib/Line.cs
+++ b/Plotly.Blazor/Traces/BarPolarLib/MarkerLib/Line.cs
@@ -110,7 +110,7 @@ namespace Plotly.Blazor.Traces.BarPolarLib.MarkerLib
         public object ColorScale { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  color .
+        ///     Sets the source reference on Chart Studio Cloud for <c>color</c>.
         /// </summary>
         [JsonPropertyName(@"colorsrc")]
         public string ColorSrc { get; set;} 
@@ -138,7 +138,7 @@ namespace Plotly.Blazor.Traces.BarPolarLib.MarkerLib
         public IList<decimal?> WidthArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  width .
+        ///     Sets the source reference on Chart Studio Cloud for <c>width</c>.
         /// </summary>
         [JsonPropertyName(@"widthsrc")]
         public string WidthSrc { get; set;} 

--- a/Plotly.Blazor/Traces/Box.cs
+++ b/Plotly.Blazor/Traces/Box.cs
@@ -64,7 +64,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> CustomData { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  customdata .
+        ///     Sets the source reference on Chart Studio Cloud for <c>customdata</c>.
         /// </summary>
         [JsonPropertyName(@"customdatasrc")]
         public string CustomDataSrc { get; set;} 
@@ -106,7 +106,7 @@ namespace Plotly.Blazor.Traces
         public IList<Plotly.Blazor.Traces.BoxLib.HoverInfoFlag?> HoverInfoArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  hoverinfo .
+        ///     Sets the source reference on Chart Studio Cloud for <c>hoverinfo</c>.
         /// </summary>
         [JsonPropertyName(@"hoverinfosrc")]
         public string HoverInfoSrc { get; set;} 
@@ -173,7 +173,7 @@ namespace Plotly.Blazor.Traces
         public IList<string> HoverTemplateArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  hovertemplate .
+        ///     Sets the source reference on Chart Studio Cloud for <c>hovertemplate</c>.
         /// </summary>
         [JsonPropertyName(@"hovertemplatesrc")]
         public string HoverTemplateSrc { get; set;} 
@@ -192,7 +192,7 @@ namespace Plotly.Blazor.Traces
         public IList<string> HoverTextArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  hovertext .
+        ///     Sets the source reference on Chart Studio Cloud for <c>hovertext</c>.
         /// </summary>
         [JsonPropertyName(@"hovertextsrc")]
         public string HoverTextSrc { get; set;} 
@@ -206,7 +206,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> Ids { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  ids .
+        ///     Sets the source reference on Chart Studio Cloud for <c>ids</c>.
         /// </summary>
         [JsonPropertyName(@"idssrc")]
         public string IdsSrc { get; set;} 
@@ -259,7 +259,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> LowerFence { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  lowerfence .
+        ///     Sets the source reference on Chart Studio Cloud for <c>lowerfence</c>.
         /// </summary>
         [JsonPropertyName(@"lowerfencesrc")]
         public string LowerFenceSrc { get; set;} 
@@ -280,7 +280,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> Mean { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  mean .
+        ///     Sets the source reference on Chart Studio Cloud for <c>mean</c>.
         /// </summary>
         [JsonPropertyName(@"meansrc")]
         public string MeanSrc { get; set;} 
@@ -293,7 +293,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> Median { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  median .
+        ///     Sets the source reference on Chart Studio Cloud for <c>median</c>.
         /// </summary>
         [JsonPropertyName(@"mediansrc")]
         public string MedianSrc { get; set;} 
@@ -328,7 +328,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> MetaArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  meta .
+        ///     Sets the source reference on Chart Studio Cloud for <c>meta</c>.
         /// </summary>
         [JsonPropertyName(@"metasrc")]
         public string MetaSrc { get; set;} 
@@ -365,7 +365,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> NotchSpan { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  notchspan .
+        ///     Sets the source reference on Chart Studio Cloud for <c>notchspan</c>.
         /// </summary>
         [JsonPropertyName(@"notchspansrc")]
         public string NotchSpanSrc { get; set;} 
@@ -415,7 +415,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> Q1 { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  q1 .
+        ///     Sets the source reference on Chart Studio Cloud for <c>q1</c>.
         /// </summary>
         [JsonPropertyName(@"q1src")]
         public string Q1Src { get; set;} 
@@ -428,7 +428,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> Q3 { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  q3 .
+        ///     Sets the source reference on Chart Studio Cloud for <c>q3</c>.
         /// </summary>
         [JsonPropertyName(@"q3src")]
         public string Q3Src { get; set;} 
@@ -459,7 +459,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> SD { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  sd .
+        ///     Sets the source reference on Chart Studio Cloud for <c>sd</c>.
         /// </summary>
         [JsonPropertyName(@"sdsrc")]
         public string SdSrc { get; set;} 
@@ -513,7 +513,7 @@ namespace Plotly.Blazor.Traces
         public IList<string> TextArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  text .
+        ///     Sets the source reference on Chart Studio Cloud for <c>text</c>.
         /// </summary>
         [JsonPropertyName(@"textsrc")]
         public string TextSrc { get; set;} 
@@ -565,7 +565,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> UpperFence { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  upperfence .
+        ///     Sets the source reference on Chart Studio Cloud for <c>upperfence</c>.
         /// </summary>
         [JsonPropertyName(@"upperfencesrc")]
         public string UpperFenceSrc { get; set;} 
@@ -659,7 +659,7 @@ namespace Plotly.Blazor.Traces
         public Plotly.Blazor.Traces.BoxLib.XPeriodAlignmentEnum? XPeriodAlignment { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  x .
+        ///     Sets the source reference on Chart Studio Cloud for <c>x</c>.
         /// </summary>
         [JsonPropertyName(@"xsrc")]
         public string XSrc { get; set;} 
@@ -730,7 +730,7 @@ namespace Plotly.Blazor.Traces
         public Plotly.Blazor.Traces.BoxLib.YPeriodAlignmentEnum? YPeriodAlignment { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  y .
+        ///     Sets the source reference on Chart Studio Cloud for <c>y</c>.
         /// </summary>
         [JsonPropertyName(@"ysrc")]
         public string YSrc { get; set;} 

--- a/Plotly.Blazor/Traces/BoxLib/HoverLabel.cs
+++ b/Plotly.Blazor/Traces/BoxLib/HoverLabel.cs
@@ -36,7 +36,7 @@ namespace Plotly.Blazor.Traces.BoxLib
         public IList<Plotly.Blazor.Traces.BoxLib.HoverLabelLib.AlignEnum?> AlignArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  align .
+        ///     Sets the source reference on Chart Studio Cloud for <c>align</c>.
         /// </summary>
         [JsonPropertyName(@"alignsrc")]
         public string AlignSrc { get; set;} 
@@ -55,7 +55,7 @@ namespace Plotly.Blazor.Traces.BoxLib
         public IList<object> BgColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  bgcolor .
+        ///     Sets the source reference on Chart Studio Cloud for <c>bgcolor</c>.
         /// </summary>
         [JsonPropertyName(@"bgcolorsrc")]
         public string BgColorSrc { get; set;} 
@@ -74,7 +74,7 @@ namespace Plotly.Blazor.Traces.BoxLib
         public IList<object> BorderColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  bordercolor .
+        ///     Sets the source reference on Chart Studio Cloud for <c>bordercolor</c>.
         /// </summary>
         [JsonPropertyName(@"bordercolorsrc")]
         public string BorderColorSrc { get; set;} 
@@ -107,7 +107,7 @@ namespace Plotly.Blazor.Traces.BoxLib
         public IList<int?> NameLengthArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  namelength .
+        ///     Sets the source reference on Chart Studio Cloud for <c>namelength</c>.
         /// </summary>
         [JsonPropertyName(@"namelengthsrc")]
         public string NameLengthSrc { get; set;} 

--- a/Plotly.Blazor/Traces/BoxLib/HoverLabelLib/Font.cs
+++ b/Plotly.Blazor/Traces/BoxLib/HoverLabelLib/Font.cs
@@ -34,7 +34,7 @@ namespace Plotly.Blazor.Traces.BoxLib.HoverLabelLib
         public IList<object> ColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  color .
+        ///     Sets the source reference on Chart Studio Cloud for <c>color</c>.
         /// </summary>
         [JsonPropertyName(@"colorsrc")]
         public string ColorSrc { get; set;} 
@@ -73,7 +73,7 @@ namespace Plotly.Blazor.Traces.BoxLib.HoverLabelLib
         public IList<string> FamilyArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  family .
+        ///     Sets the source reference on Chart Studio Cloud for <c>family</c>.
         /// </summary>
         [JsonPropertyName(@"familysrc")]
         public string FamilySrc { get; set;} 
@@ -92,7 +92,7 @@ namespace Plotly.Blazor.Traces.BoxLib.HoverLabelLib
         public IList<decimal?> SizeArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  size .
+        ///     Sets the source reference on Chart Studio Cloud for <c>size</c>.
         /// </summary>
         [JsonPropertyName(@"sizesrc")]
         public string SizeSrc { get; set;} 

--- a/Plotly.Blazor/Traces/Candlestick.cs
+++ b/Plotly.Blazor/Traces/Candlestick.cs
@@ -32,7 +32,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> Close { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  close .
+        ///     Sets the source reference on Chart Studio Cloud for <c>close</c>.
         /// </summary>
         [JsonPropertyName(@"closesrc")]
         public string CloseSrc { get; set;} 
@@ -46,7 +46,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> CustomData { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  customdata .
+        ///     Sets the source reference on Chart Studio Cloud for <c>customdata</c>.
         /// </summary>
         [JsonPropertyName(@"customdatasrc")]
         public string CustomDataSrc { get; set;} 
@@ -64,7 +64,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> High { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  high .
+        ///     Sets the source reference on Chart Studio Cloud for <c>high</c>.
         /// </summary>
         [JsonPropertyName(@"highsrc")]
         public string HighSrc { get; set;} 
@@ -87,7 +87,7 @@ namespace Plotly.Blazor.Traces
         public IList<Plotly.Blazor.Traces.CandlestickLib.HoverInfoFlag?> HoverInfoArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  hoverinfo .
+        ///     Sets the source reference on Chart Studio Cloud for <c>hoverinfo</c>.
         /// </summary>
         [JsonPropertyName(@"hoverinfosrc")]
         public string HoverInfoSrc { get; set;} 
@@ -112,7 +112,7 @@ namespace Plotly.Blazor.Traces
         public IList<string> HoverTextArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  hovertext .
+        ///     Sets the source reference on Chart Studio Cloud for <c>hovertext</c>.
         /// </summary>
         [JsonPropertyName(@"hovertextsrc")]
         public string HoverTextSrc { get; set;} 
@@ -126,7 +126,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> Ids { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  ids .
+        ///     Sets the source reference on Chart Studio Cloud for <c>ids</c>.
         /// </summary>
         [JsonPropertyName(@"idssrc")]
         public string IdsSrc { get; set;} 
@@ -173,7 +173,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> Low { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  low .
+        ///     Sets the source reference on Chart Studio Cloud for <c>low</c>.
         /// </summary>
         [JsonPropertyName(@"lowsrc")]
         public string LowSrc { get; set;} 
@@ -208,7 +208,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> MetaArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  meta .
+        ///     Sets the source reference on Chart Studio Cloud for <c>meta</c>.
         /// </summary>
         [JsonPropertyName(@"metasrc")]
         public string MetaSrc { get; set;} 
@@ -232,7 +232,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> Open { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  open .
+        ///     Sets the source reference on Chart Studio Cloud for <c>open</c>.
         /// </summary>
         [JsonPropertyName(@"opensrc")]
         public string OpenSrc { get; set;} 
@@ -278,7 +278,7 @@ namespace Plotly.Blazor.Traces
         public IList<string> TextArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  text .
+        ///     Sets the source reference on Chart Studio Cloud for <c>text</c>.
         /// </summary>
         [JsonPropertyName(@"textsrc")]
         public string TextSrc { get; set;} 
@@ -387,7 +387,7 @@ namespace Plotly.Blazor.Traces
         public Plotly.Blazor.Traces.CandlestickLib.XPeriodAlignmentEnum? XPeriodAlignment { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  x .
+        ///     Sets the source reference on Chart Studio Cloud for <c>x</c>.
         /// </summary>
         [JsonPropertyName(@"xsrc")]
         public string XSrc { get; set;} 

--- a/Plotly.Blazor/Traces/CandlestickLib/HoverLabel.cs
+++ b/Plotly.Blazor/Traces/CandlestickLib/HoverLabel.cs
@@ -36,7 +36,7 @@ namespace Plotly.Blazor.Traces.CandlestickLib
         public IList<Plotly.Blazor.Traces.CandlestickLib.HoverLabelLib.AlignEnum?> AlignArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  align .
+        ///     Sets the source reference on Chart Studio Cloud for <c>align</c>.
         /// </summary>
         [JsonPropertyName(@"alignsrc")]
         public string AlignSrc { get; set;} 
@@ -55,7 +55,7 @@ namespace Plotly.Blazor.Traces.CandlestickLib
         public IList<object> BgColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  bgcolor .
+        ///     Sets the source reference on Chart Studio Cloud for <c>bgcolor</c>.
         /// </summary>
         [JsonPropertyName(@"bgcolorsrc")]
         public string BgColorSrc { get; set;} 
@@ -74,7 +74,7 @@ namespace Plotly.Blazor.Traces.CandlestickLib
         public IList<object> BorderColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  bordercolor .
+        ///     Sets the source reference on Chart Studio Cloud for <c>bordercolor</c>.
         /// </summary>
         [JsonPropertyName(@"bordercolorsrc")]
         public string BorderColorSrc { get; set;} 
@@ -107,7 +107,7 @@ namespace Plotly.Blazor.Traces.CandlestickLib
         public IList<int?> NameLengthArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  namelength .
+        ///     Sets the source reference on Chart Studio Cloud for <c>namelength</c>.
         /// </summary>
         [JsonPropertyName(@"namelengthsrc")]
         public string NameLengthSrc { get; set;} 

--- a/Plotly.Blazor/Traces/CandlestickLib/HoverLabelLib/Font.cs
+++ b/Plotly.Blazor/Traces/CandlestickLib/HoverLabelLib/Font.cs
@@ -34,7 +34,7 @@ namespace Plotly.Blazor.Traces.CandlestickLib.HoverLabelLib
         public IList<object> ColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  color .
+        ///     Sets the source reference on Chart Studio Cloud for <c>color</c>.
         /// </summary>
         [JsonPropertyName(@"colorsrc")]
         public string ColorSrc { get; set;} 
@@ -73,7 +73,7 @@ namespace Plotly.Blazor.Traces.CandlestickLib.HoverLabelLib
         public IList<string> FamilyArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  family .
+        ///     Sets the source reference on Chart Studio Cloud for <c>family</c>.
         /// </summary>
         [JsonPropertyName(@"familysrc")]
         public string FamilySrc { get; set;} 
@@ -92,7 +92,7 @@ namespace Plotly.Blazor.Traces.CandlestickLib.HoverLabelLib
         public IList<decimal?> SizeArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  size .
+        ///     Sets the source reference on Chart Studio Cloud for <c>size</c>.
         /// </summary>
         [JsonPropertyName(@"sizesrc")]
         public string SizeSrc { get; set;} 

--- a/Plotly.Blazor/Traces/Carpet.cs
+++ b/Plotly.Blazor/Traces/Carpet.cs
@@ -45,7 +45,7 @@ namespace Plotly.Blazor.Traces
         public Plotly.Blazor.Traces.CarpetLib.AAxis AAxis { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  a .
+        ///     Sets the source reference on Chart Studio Cloud for <c>a</c>.
         /// </summary>
         [JsonPropertyName(@"asrc")]
         public string ASrc { get; set;} 
@@ -70,7 +70,7 @@ namespace Plotly.Blazor.Traces
         public Plotly.Blazor.Traces.CarpetLib.BAxis BAxis { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  b .
+        ///     Sets the source reference on Chart Studio Cloud for <c>b</c>.
         /// </summary>
         [JsonPropertyName(@"bsrc")]
         public string BSrc { get; set;} 
@@ -106,7 +106,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> CustomData { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  customdata .
+        ///     Sets the source reference on Chart Studio Cloud for <c>customdata</c>.
         /// </summary>
         [JsonPropertyName(@"customdatasrc")]
         public string CustomDataSrc { get; set;} 
@@ -138,7 +138,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> Ids { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  ids .
+        ///     Sets the source reference on Chart Studio Cloud for <c>ids</c>.
         /// </summary>
         [JsonPropertyName(@"idssrc")]
         public string IdsSrc { get; set;} 
@@ -189,7 +189,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> MetaArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  meta .
+        ///     Sets the source reference on Chart Studio Cloud for <c>meta</c>.
         /// </summary>
         [JsonPropertyName(@"metasrc")]
         public string MetaSrc { get; set;} 
@@ -260,7 +260,7 @@ namespace Plotly.Blazor.Traces
         public string XAxis { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  x .
+        ///     Sets the source reference on Chart Studio Cloud for <c>x</c>.
         /// </summary>
         [JsonPropertyName(@"xsrc")]
         public string XSrc { get; set;} 
@@ -280,7 +280,7 @@ namespace Plotly.Blazor.Traces
         public string YAxis { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  y .
+        ///     Sets the source reference on Chart Studio Cloud for <c>y</c>.
         /// </summary>
         [JsonPropertyName(@"ysrc")]
         public string YSrc { get; set;} 

--- a/Plotly.Blazor/Traces/CarpetLib/AAxis.cs
+++ b/Plotly.Blazor/Traces/CarpetLib/AAxis.cs
@@ -56,7 +56,7 @@ namespace Plotly.Blazor.Traces.CarpetLib
         public IList<object> CategoryArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  categoryarray .
+        ///     Sets the source reference on Chart Studio Cloud for <c>categoryarray</c>.
         /// </summary>
         [JsonPropertyName(@"categoryarraysrc")]
         public string CategoryArraySrc { get; set;} 
@@ -362,7 +362,7 @@ namespace Plotly.Blazor.Traces.CarpetLib
         public IList<object> TickText { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  ticktext .
+        ///     Sets the source reference on Chart Studio Cloud for <c>ticktext</c>.
         /// </summary>
         [JsonPropertyName(@"ticktextsrc")]
         public string TickTextSrc { get; set;} 
@@ -375,7 +375,7 @@ namespace Plotly.Blazor.Traces.CarpetLib
         public IList<object> TickVals { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  tickvals .
+        ///     Sets the source reference on Chart Studio Cloud for <c>tickvals</c>.
         /// </summary>
         [JsonPropertyName(@"tickvalssrc")]
         public string TickValsSrc { get; set;} 

--- a/Plotly.Blazor/Traces/CarpetLib/BAxis.cs
+++ b/Plotly.Blazor/Traces/CarpetLib/BAxis.cs
@@ -56,7 +56,7 @@ namespace Plotly.Blazor.Traces.CarpetLib
         public IList<object> CategoryArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  categoryarray .
+        ///     Sets the source reference on Chart Studio Cloud for <c>categoryarray</c>.
         /// </summary>
         [JsonPropertyName(@"categoryarraysrc")]
         public string CategoryArraySrc { get; set;} 
@@ -362,7 +362,7 @@ namespace Plotly.Blazor.Traces.CarpetLib
         public IList<object> TickText { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  ticktext .
+        ///     Sets the source reference on Chart Studio Cloud for <c>ticktext</c>.
         /// </summary>
         [JsonPropertyName(@"ticktextsrc")]
         public string TickTextSrc { get; set;} 
@@ -375,7 +375,7 @@ namespace Plotly.Blazor.Traces.CarpetLib
         public IList<object> TickVals { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  tickvals .
+        ///     Sets the source reference on Chart Studio Cloud for <c>tickvals</c>.
         /// </summary>
         [JsonPropertyName(@"tickvalssrc")]
         public string TickValsSrc { get; set;} 

--- a/Plotly.Blazor/Traces/Choropleth.cs
+++ b/Plotly.Blazor/Traces/Choropleth.cs
@@ -72,7 +72,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> CustomData { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  customdata .
+        ///     Sets the source reference on Chart Studio Cloud for <c>customdata</c>.
         /// </summary>
         [JsonPropertyName(@"customdatasrc")]
         public string CustomDataSrc { get; set;} 
@@ -121,7 +121,7 @@ namespace Plotly.Blazor.Traces
         public IList<Plotly.Blazor.Traces.ChoroplethLib.HoverInfoFlag?> HoverInfoArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  hoverinfo .
+        ///     Sets the source reference on Chart Studio Cloud for <c>hoverinfo</c>.
         /// </summary>
         [JsonPropertyName(@"hoverinfosrc")]
         public string HoverInfoSrc { get; set;} 
@@ -182,7 +182,7 @@ namespace Plotly.Blazor.Traces
         public IList<string> HoverTemplateArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  hovertemplate .
+        ///     Sets the source reference on Chart Studio Cloud for <c>hovertemplate</c>.
         /// </summary>
         [JsonPropertyName(@"hovertemplatesrc")]
         public string HoverTemplateSrc { get; set;} 
@@ -201,7 +201,7 @@ namespace Plotly.Blazor.Traces
         public IList<string> HoverTextArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  hovertext .
+        ///     Sets the source reference on Chart Studio Cloud for <c>hovertext</c>.
         /// </summary>
         [JsonPropertyName(@"hovertextsrc")]
         public string HoverTextSrc { get; set;} 
@@ -215,7 +215,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> Ids { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  ids .
+        ///     Sets the source reference on Chart Studio Cloud for <c>ids</c>.
         /// </summary>
         [JsonPropertyName(@"idssrc")]
         public string IdsSrc { get; set;} 
@@ -261,7 +261,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> Locations { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  locations .
+        ///     Sets the source reference on Chart Studio Cloud for <c>locations</c>.
         /// </summary>
         [JsonPropertyName(@"locationssrc")]
         public string LocationsSrc { get; set;} 
@@ -302,7 +302,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> MetaArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  meta .
+        ///     Sets the source reference on Chart Studio Cloud for <c>meta</c>.
         /// </summary>
         [JsonPropertyName(@"metasrc")]
         public string MetaSrc { get; set;} 
@@ -370,7 +370,7 @@ namespace Plotly.Blazor.Traces
         public IList<string> TextArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  text .
+        ///     Sets the source reference on Chart Studio Cloud for <c>text</c>.
         /// </summary>
         [JsonPropertyName(@"textsrc")]
         public string TextSrc { get; set;} 
@@ -457,7 +457,7 @@ namespace Plotly.Blazor.Traces
         public decimal? ZMin { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  z .
+        ///     Sets the source reference on Chart Studio Cloud for <c>z</c>.
         /// </summary>
         [JsonPropertyName(@"zsrc")]
         public string ZSrc { get; set;} 

--- a/Plotly.Blazor/Traces/ChoroplethLib/HoverLabel.cs
+++ b/Plotly.Blazor/Traces/ChoroplethLib/HoverLabel.cs
@@ -36,7 +36,7 @@ namespace Plotly.Blazor.Traces.ChoroplethLib
         public IList<Plotly.Blazor.Traces.ChoroplethLib.HoverLabelLib.AlignEnum?> AlignArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  align .
+        ///     Sets the source reference on Chart Studio Cloud for <c>align</c>.
         /// </summary>
         [JsonPropertyName(@"alignsrc")]
         public string AlignSrc { get; set;} 
@@ -55,7 +55,7 @@ namespace Plotly.Blazor.Traces.ChoroplethLib
         public IList<object> BgColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  bgcolor .
+        ///     Sets the source reference on Chart Studio Cloud for <c>bgcolor</c>.
         /// </summary>
         [JsonPropertyName(@"bgcolorsrc")]
         public string BgColorSrc { get; set;} 
@@ -74,7 +74,7 @@ namespace Plotly.Blazor.Traces.ChoroplethLib
         public IList<object> BorderColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  bordercolor .
+        ///     Sets the source reference on Chart Studio Cloud for <c>bordercolor</c>.
         /// </summary>
         [JsonPropertyName(@"bordercolorsrc")]
         public string BorderColorSrc { get; set;} 
@@ -107,7 +107,7 @@ namespace Plotly.Blazor.Traces.ChoroplethLib
         public IList<int?> NameLengthArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  namelength .
+        ///     Sets the source reference on Chart Studio Cloud for <c>namelength</c>.
         /// </summary>
         [JsonPropertyName(@"namelengthsrc")]
         public string NameLengthSrc { get; set;} 

--- a/Plotly.Blazor/Traces/ChoroplethLib/HoverLabelLib/Font.cs
+++ b/Plotly.Blazor/Traces/ChoroplethLib/HoverLabelLib/Font.cs
@@ -34,7 +34,7 @@ namespace Plotly.Blazor.Traces.ChoroplethLib.HoverLabelLib
         public IList<object> ColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  color .
+        ///     Sets the source reference on Chart Studio Cloud for <c>color</c>.
         /// </summary>
         [JsonPropertyName(@"colorsrc")]
         public string ColorSrc { get; set;} 
@@ -73,7 +73,7 @@ namespace Plotly.Blazor.Traces.ChoroplethLib.HoverLabelLib
         public IList<string> FamilyArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  family .
+        ///     Sets the source reference on Chart Studio Cloud for <c>family</c>.
         /// </summary>
         [JsonPropertyName(@"familysrc")]
         public string FamilySrc { get; set;} 
@@ -92,7 +92,7 @@ namespace Plotly.Blazor.Traces.ChoroplethLib.HoverLabelLib
         public IList<decimal?> SizeArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  size .
+        ///     Sets the source reference on Chart Studio Cloud for <c>size</c>.
         /// </summary>
         [JsonPropertyName(@"sizesrc")]
         public string SizeSrc { get; set;} 

--- a/Plotly.Blazor/Traces/ChoroplethLib/Marker.cs
+++ b/Plotly.Blazor/Traces/ChoroplethLib/Marker.cs
@@ -40,7 +40,7 @@ namespace Plotly.Blazor.Traces.ChoroplethLib
         public IList<decimal?> OpacityArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  opacity .
+        ///     Sets the source reference on Chart Studio Cloud for <c>opacity</c>.
         /// </summary>
         [JsonPropertyName(@"opacitysrc")]
         public string OpacitySrc { get; set;} 

--- a/Plotly.Blazor/Traces/ChoroplethLib/MarkerLib/Line.cs
+++ b/Plotly.Blazor/Traces/ChoroplethLib/MarkerLib/Line.cs
@@ -40,7 +40,7 @@ namespace Plotly.Blazor.Traces.ChoroplethLib.MarkerLib
         public IList<object> ColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  color .
+        ///     Sets the source reference on Chart Studio Cloud for <c>color</c>.
         /// </summary>
         [JsonPropertyName(@"colorsrc")]
         public string ColorSrc { get; set;} 
@@ -59,7 +59,7 @@ namespace Plotly.Blazor.Traces.ChoroplethLib.MarkerLib
         public IList<decimal?> WidthArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  width .
+        ///     Sets the source reference on Chart Studio Cloud for <c>width</c>.
         /// </summary>
         [JsonPropertyName(@"widthsrc")]
         public string WidthSrc { get; set;} 

--- a/Plotly.Blazor/Traces/ChoroplethMapBox.cs
+++ b/Plotly.Blazor/Traces/ChoroplethMapBox.cs
@@ -81,7 +81,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> CustomData { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  customdata .
+        ///     Sets the source reference on Chart Studio Cloud for <c>customdata</c>.
         /// </summary>
         [JsonPropertyName(@"customdatasrc")]
         public string CustomDataSrc { get; set;} 
@@ -121,7 +121,7 @@ namespace Plotly.Blazor.Traces
         public IList<Plotly.Blazor.Traces.ChoroplethMapBoxLib.HoverInfoFlag?> HoverInfoArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  hoverinfo .
+        ///     Sets the source reference on Chart Studio Cloud for <c>hoverinfo</c>.
         /// </summary>
         [JsonPropertyName(@"hoverinfosrc")]
         public string HoverInfoSrc { get; set;} 
@@ -182,7 +182,7 @@ namespace Plotly.Blazor.Traces
         public IList<string> HoverTemplateArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  hovertemplate .
+        ///     Sets the source reference on Chart Studio Cloud for <c>hovertemplate</c>.
         /// </summary>
         [JsonPropertyName(@"hovertemplatesrc")]
         public string HoverTemplateSrc { get; set;} 
@@ -201,7 +201,7 @@ namespace Plotly.Blazor.Traces
         public IList<string> HoverTextArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  hovertext .
+        ///     Sets the source reference on Chart Studio Cloud for <c>hovertext</c>.
         /// </summary>
         [JsonPropertyName(@"hovertextsrc")]
         public string HoverTextSrc { get; set;} 
@@ -215,7 +215,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> Ids { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  ids .
+        ///     Sets the source reference on Chart Studio Cloud for <c>ids</c>.
         /// </summary>
         [JsonPropertyName(@"idssrc")]
         public string IdsSrc { get; set;} 
@@ -251,7 +251,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> Locations { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  locations .
+        ///     Sets the source reference on Chart Studio Cloud for <c>locations</c>.
         /// </summary>
         [JsonPropertyName(@"locationssrc")]
         public string LocationsSrc { get; set;} 
@@ -292,7 +292,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> MetaArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  meta .
+        ///     Sets the source reference on Chart Studio Cloud for <c>meta</c>.
         /// </summary>
         [JsonPropertyName(@"metasrc")]
         public string MetaSrc { get; set;} 
@@ -368,7 +368,7 @@ namespace Plotly.Blazor.Traces
         public IList<string> TextArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  text .
+        ///     Sets the source reference on Chart Studio Cloud for <c>text</c>.
         /// </summary>
         [JsonPropertyName(@"textsrc")]
         public string TextSrc { get; set;} 
@@ -455,7 +455,7 @@ namespace Plotly.Blazor.Traces
         public decimal? ZMin { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  z .
+        ///     Sets the source reference on Chart Studio Cloud for <c>z</c>.
         /// </summary>
         [JsonPropertyName(@"zsrc")]
         public string ZSrc { get; set;} 

--- a/Plotly.Blazor/Traces/ChoroplethMapBoxLib/HoverLabel.cs
+++ b/Plotly.Blazor/Traces/ChoroplethMapBoxLib/HoverLabel.cs
@@ -36,7 +36,7 @@ namespace Plotly.Blazor.Traces.ChoroplethMapBoxLib
         public IList<Plotly.Blazor.Traces.ChoroplethMapBoxLib.HoverLabelLib.AlignEnum?> AlignArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  align .
+        ///     Sets the source reference on Chart Studio Cloud for <c>align</c>.
         /// </summary>
         [JsonPropertyName(@"alignsrc")]
         public string AlignSrc { get; set;} 
@@ -55,7 +55,7 @@ namespace Plotly.Blazor.Traces.ChoroplethMapBoxLib
         public IList<object> BgColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  bgcolor .
+        ///     Sets the source reference on Chart Studio Cloud for <c>bgcolor</c>.
         /// </summary>
         [JsonPropertyName(@"bgcolorsrc")]
         public string BgColorSrc { get; set;} 
@@ -74,7 +74,7 @@ namespace Plotly.Blazor.Traces.ChoroplethMapBoxLib
         public IList<object> BorderColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  bordercolor .
+        ///     Sets the source reference on Chart Studio Cloud for <c>bordercolor</c>.
         /// </summary>
         [JsonPropertyName(@"bordercolorsrc")]
         public string BorderColorSrc { get; set;} 
@@ -107,7 +107,7 @@ namespace Plotly.Blazor.Traces.ChoroplethMapBoxLib
         public IList<int?> NameLengthArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  namelength .
+        ///     Sets the source reference on Chart Studio Cloud for <c>namelength</c>.
         /// </summary>
         [JsonPropertyName(@"namelengthsrc")]
         public string NameLengthSrc { get; set;} 

--- a/Plotly.Blazor/Traces/ChoroplethMapBoxLib/HoverLabelLib/Font.cs
+++ b/Plotly.Blazor/Traces/ChoroplethMapBoxLib/HoverLabelLib/Font.cs
@@ -34,7 +34,7 @@ namespace Plotly.Blazor.Traces.ChoroplethMapBoxLib.HoverLabelLib
         public IList<object> ColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  color .
+        ///     Sets the source reference on Chart Studio Cloud for <c>color</c>.
         /// </summary>
         [JsonPropertyName(@"colorsrc")]
         public string ColorSrc { get; set;} 
@@ -73,7 +73,7 @@ namespace Plotly.Blazor.Traces.ChoroplethMapBoxLib.HoverLabelLib
         public IList<string> FamilyArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  family .
+        ///     Sets the source reference on Chart Studio Cloud for <c>family</c>.
         /// </summary>
         [JsonPropertyName(@"familysrc")]
         public string FamilySrc { get; set;} 
@@ -92,7 +92,7 @@ namespace Plotly.Blazor.Traces.ChoroplethMapBoxLib.HoverLabelLib
         public IList<decimal?> SizeArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  size .
+        ///     Sets the source reference on Chart Studio Cloud for <c>size</c>.
         /// </summary>
         [JsonPropertyName(@"sizesrc")]
         public string SizeSrc { get; set;} 

--- a/Plotly.Blazor/Traces/ChoroplethMapBoxLib/Marker.cs
+++ b/Plotly.Blazor/Traces/ChoroplethMapBoxLib/Marker.cs
@@ -40,7 +40,7 @@ namespace Plotly.Blazor.Traces.ChoroplethMapBoxLib
         public IList<decimal?> OpacityArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  opacity .
+        ///     Sets the source reference on Chart Studio Cloud for <c>opacity</c>.
         /// </summary>
         [JsonPropertyName(@"opacitysrc")]
         public string OpacitySrc { get; set;} 

--- a/Plotly.Blazor/Traces/ChoroplethMapBoxLib/MarkerLib/Line.cs
+++ b/Plotly.Blazor/Traces/ChoroplethMapBoxLib/MarkerLib/Line.cs
@@ -40,7 +40,7 @@ namespace Plotly.Blazor.Traces.ChoroplethMapBoxLib.MarkerLib
         public IList<object> ColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  color .
+        ///     Sets the source reference on Chart Studio Cloud for <c>color</c>.
         /// </summary>
         [JsonPropertyName(@"colorsrc")]
         public string ColorSrc { get; set;} 
@@ -59,7 +59,7 @@ namespace Plotly.Blazor.Traces.ChoroplethMapBoxLib.MarkerLib
         public IList<decimal?> WidthArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  width .
+        ///     Sets the source reference on Chart Studio Cloud for <c>width</c>.
         /// </summary>
         [JsonPropertyName(@"widthsrc")]
         public string WidthSrc { get; set;} 

--- a/Plotly.Blazor/Traces/Cone.cs
+++ b/Plotly.Blazor/Traces/Cone.cs
@@ -111,7 +111,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> CustomData { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  customdata .
+        ///     Sets the source reference on Chart Studio Cloud for <c>customdata</c>.
         /// </summary>
         [JsonPropertyName(@"customdatasrc")]
         public string CustomDataSrc { get; set;} 
@@ -134,7 +134,7 @@ namespace Plotly.Blazor.Traces
         public IList<Plotly.Blazor.Traces.ConeLib.HoverInfoFlag?> HoverInfoArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  hoverinfo .
+        ///     Sets the source reference on Chart Studio Cloud for <c>hoverinfo</c>.
         /// </summary>
         [JsonPropertyName(@"hoverinfosrc")]
         public string HoverInfoSrc { get; set;} 
@@ -195,7 +195,7 @@ namespace Plotly.Blazor.Traces
         public IList<string> HoverTemplateArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  hovertemplate .
+        ///     Sets the source reference on Chart Studio Cloud for <c>hovertemplate</c>.
         /// </summary>
         [JsonPropertyName(@"hovertemplatesrc")]
         public string HoverTemplateSrc { get; set;} 
@@ -214,7 +214,7 @@ namespace Plotly.Blazor.Traces
         public IList<string> HoverTextArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  hovertext .
+        ///     Sets the source reference on Chart Studio Cloud for <c>hovertext</c>.
         /// </summary>
         [JsonPropertyName(@"hovertextsrc")]
         public string HoverTextSrc { get; set;} 
@@ -228,7 +228,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> Ids { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  ids .
+        ///     Sets the source reference on Chart Studio Cloud for <c>ids</c>.
         /// </summary>
         [JsonPropertyName(@"idssrc")]
         public string IdsSrc { get; set;} 
@@ -298,7 +298,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> MetaArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  meta .
+        ///     Sets the source reference on Chart Studio Cloud for <c>meta</c>.
         /// </summary>
         [JsonPropertyName(@"metasrc")]
         public string MetaSrc { get; set;} 
@@ -395,7 +395,7 @@ namespace Plotly.Blazor.Traces
         public IList<string> TextArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  text .
+        ///     Sets the source reference on Chart Studio Cloud for <c>text</c>.
         /// </summary>
         [JsonPropertyName(@"textsrc")]
         public string TextSrc { get; set;} 
@@ -439,7 +439,7 @@ namespace Plotly.Blazor.Traces
         public object UiRevision { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  u .
+        ///     Sets the source reference on Chart Studio Cloud for <c>u</c>.
         /// </summary>
         [JsonPropertyName(@"usrc")]
         public string USrc { get; set;} 
@@ -467,7 +467,7 @@ namespace Plotly.Blazor.Traces
         public Plotly.Blazor.Traces.ConeLib.VisibleEnum? Visible { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  v .
+        ///     Sets the source reference on Chart Studio Cloud for <c>v</c>.
         /// </summary>
         [JsonPropertyName(@"vsrc")]
         public string VSrc { get; set;} 
@@ -487,7 +487,7 @@ namespace Plotly.Blazor.Traces
         public string WHoverFormat { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  w .
+        ///     Sets the source reference on Chart Studio Cloud for <c>w</c>.
         /// </summary>
         [JsonPropertyName(@"wsrc")]
         public string WSrc { get; set;} 
@@ -512,7 +512,7 @@ namespace Plotly.Blazor.Traces
         public string XHoverFormat { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  x .
+        ///     Sets the source reference on Chart Studio Cloud for <c>x</c>.
         /// </summary>
         [JsonPropertyName(@"xsrc")]
         public string XSrc { get; set;} 
@@ -537,7 +537,7 @@ namespace Plotly.Blazor.Traces
         public string YHoverFormat { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  y .
+        ///     Sets the source reference on Chart Studio Cloud for <c>y</c>.
         /// </summary>
         [JsonPropertyName(@"ysrc")]
         public string YSrc { get; set;} 
@@ -562,7 +562,7 @@ namespace Plotly.Blazor.Traces
         public string ZHoverFormat { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  z .
+        ///     Sets the source reference on Chart Studio Cloud for <c>z</c>.
         /// </summary>
         [JsonPropertyName(@"zsrc")]
         public string ZSrc { get; set;} 

--- a/Plotly.Blazor/Traces/ConeLib/HoverLabel.cs
+++ b/Plotly.Blazor/Traces/ConeLib/HoverLabel.cs
@@ -36,7 +36,7 @@ namespace Plotly.Blazor.Traces.ConeLib
         public IList<Plotly.Blazor.Traces.ConeLib.HoverLabelLib.AlignEnum?> AlignArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  align .
+        ///     Sets the source reference on Chart Studio Cloud for <c>align</c>.
         /// </summary>
         [JsonPropertyName(@"alignsrc")]
         public string AlignSrc { get; set;} 
@@ -55,7 +55,7 @@ namespace Plotly.Blazor.Traces.ConeLib
         public IList<object> BgColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  bgcolor .
+        ///     Sets the source reference on Chart Studio Cloud for <c>bgcolor</c>.
         /// </summary>
         [JsonPropertyName(@"bgcolorsrc")]
         public string BgColorSrc { get; set;} 
@@ -74,7 +74,7 @@ namespace Plotly.Blazor.Traces.ConeLib
         public IList<object> BorderColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  bordercolor .
+        ///     Sets the source reference on Chart Studio Cloud for <c>bordercolor</c>.
         /// </summary>
         [JsonPropertyName(@"bordercolorsrc")]
         public string BorderColorSrc { get; set;} 
@@ -107,7 +107,7 @@ namespace Plotly.Blazor.Traces.ConeLib
         public IList<int?> NameLengthArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  namelength .
+        ///     Sets the source reference on Chart Studio Cloud for <c>namelength</c>.
         /// </summary>
         [JsonPropertyName(@"namelengthsrc")]
         public string NameLengthSrc { get; set;} 

--- a/Plotly.Blazor/Traces/ConeLib/HoverLabelLib/Font.cs
+++ b/Plotly.Blazor/Traces/ConeLib/HoverLabelLib/Font.cs
@@ -34,7 +34,7 @@ namespace Plotly.Blazor.Traces.ConeLib.HoverLabelLib
         public IList<object> ColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  color .
+        ///     Sets the source reference on Chart Studio Cloud for <c>color</c>.
         /// </summary>
         [JsonPropertyName(@"colorsrc")]
         public string ColorSrc { get; set;} 
@@ -73,7 +73,7 @@ namespace Plotly.Blazor.Traces.ConeLib.HoverLabelLib
         public IList<string> FamilyArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  family .
+        ///     Sets the source reference on Chart Studio Cloud for <c>family</c>.
         /// </summary>
         [JsonPropertyName(@"familysrc")]
         public string FamilySrc { get; set;} 
@@ -92,7 +92,7 @@ namespace Plotly.Blazor.Traces.ConeLib.HoverLabelLib
         public IList<decimal?> SizeArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  size .
+        ///     Sets the source reference on Chart Studio Cloud for <c>size</c>.
         /// </summary>
         [JsonPropertyName(@"sizesrc")]
         public string SizeSrc { get; set;} 

--- a/Plotly.Blazor/Traces/ContourCarpet.cs
+++ b/Plotly.Blazor/Traces/ContourCarpet.cs
@@ -39,7 +39,7 @@ namespace Plotly.Blazor.Traces
         public object A0 { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  a .
+        ///     Sets the source reference on Chart Studio Cloud for <c>a</c>.
         /// </summary>
         [JsonPropertyName(@"asrc")]
         public string ASrc { get; set;} 
@@ -85,7 +85,7 @@ namespace Plotly.Blazor.Traces
         public object B0 { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  b .
+        ///     Sets the source reference on Chart Studio Cloud for <c>b</c>.
         /// </summary>
         [JsonPropertyName(@"bsrc")]
         public string BSrc { get; set;} 
@@ -148,7 +148,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> CustomData { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  customdata .
+        ///     Sets the source reference on Chart Studio Cloud for <c>customdata</c>.
         /// </summary>
         [JsonPropertyName(@"customdatasrc")]
         public string CustomDataSrc { get; set;} 
@@ -180,7 +180,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> HoverText { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  hovertext .
+        ///     Sets the source reference on Chart Studio Cloud for <c>hovertext</c>.
         /// </summary>
         [JsonPropertyName(@"hovertextsrc")]
         public string HoverTextSrc { get; set;} 
@@ -194,7 +194,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> Ids { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  ids .
+        ///     Sets the source reference on Chart Studio Cloud for <c>ids</c>.
         /// </summary>
         [JsonPropertyName(@"idssrc")]
         public string IdsSrc { get; set;} 
@@ -258,7 +258,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> MetaArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  meta .
+        ///     Sets the source reference on Chart Studio Cloud for <c>meta</c>.
         /// </summary>
         [JsonPropertyName(@"metasrc")]
         public string MetaSrc { get; set;} 
@@ -318,7 +318,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> Text { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  text .
+        ///     Sets the source reference on Chart Studio Cloud for <c>text</c>.
         /// </summary>
         [JsonPropertyName(@"textsrc")]
         public string TextSrc { get; set;} 
@@ -415,7 +415,7 @@ namespace Plotly.Blazor.Traces
         public decimal? ZMin { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  z .
+        ///     Sets the source reference on Chart Studio Cloud for <c>z</c>.
         /// </summary>
         [JsonPropertyName(@"zsrc")]
         public string ZSrc { get; set;} 

--- a/Plotly.Blazor/Traces/ContourLib/HoverLabel.cs
+++ b/Plotly.Blazor/Traces/ContourLib/HoverLabel.cs
@@ -36,7 +36,7 @@ namespace Plotly.Blazor.Traces.ContourLib
         public IList<Plotly.Blazor.Traces.ContourLib.HoverLabelLib.AlignEnum?> AlignArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  align .
+        ///     Sets the source reference on Chart Studio Cloud for <c>align</c>.
         /// </summary>
         [JsonPropertyName(@"alignsrc")]
         public string AlignSrc { get; set;} 
@@ -55,7 +55,7 @@ namespace Plotly.Blazor.Traces.ContourLib
         public IList<object> BgColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  bgcolor .
+        ///     Sets the source reference on Chart Studio Cloud for <c>bgcolor</c>.
         /// </summary>
         [JsonPropertyName(@"bgcolorsrc")]
         public string BgColorSrc { get; set;} 
@@ -74,7 +74,7 @@ namespace Plotly.Blazor.Traces.ContourLib
         public IList<object> BorderColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  bordercolor .
+        ///     Sets the source reference on Chart Studio Cloud for <c>bordercolor</c>.
         /// </summary>
         [JsonPropertyName(@"bordercolorsrc")]
         public string BorderColorSrc { get; set;} 
@@ -107,7 +107,7 @@ namespace Plotly.Blazor.Traces.ContourLib
         public IList<int?> NameLengthArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  namelength .
+        ///     Sets the source reference on Chart Studio Cloud for <c>namelength</c>.
         /// </summary>
         [JsonPropertyName(@"namelengthsrc")]
         public string NameLengthSrc { get; set;} 

--- a/Plotly.Blazor/Traces/ContourLib/HoverLabelLib/Font.cs
+++ b/Plotly.Blazor/Traces/ContourLib/HoverLabelLib/Font.cs
@@ -34,7 +34,7 @@ namespace Plotly.Blazor.Traces.ContourLib.HoverLabelLib
         public IList<object> ColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  color .
+        ///     Sets the source reference on Chart Studio Cloud for <c>color</c>.
         /// </summary>
         [JsonPropertyName(@"colorsrc")]
         public string ColorSrc { get; set;} 
@@ -73,7 +73,7 @@ namespace Plotly.Blazor.Traces.ContourLib.HoverLabelLib
         public IList<string> FamilyArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  family .
+        ///     Sets the source reference on Chart Studio Cloud for <c>family</c>.
         /// </summary>
         [JsonPropertyName(@"familysrc")]
         public string FamilySrc { get; set;} 
@@ -92,7 +92,7 @@ namespace Plotly.Blazor.Traces.ContourLib.HoverLabelLib
         public IList<decimal?> SizeArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  size .
+        ///     Sets the source reference on Chart Studio Cloud for <c>size</c>.
         /// </summary>
         [JsonPropertyName(@"sizesrc")]
         public string SizeSrc { get; set;} 

--- a/Plotly.Blazor/Traces/DensityMapBox.cs
+++ b/Plotly.Blazor/Traces/DensityMapBox.cs
@@ -81,7 +81,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> CustomData { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  customdata .
+        ///     Sets the source reference on Chart Studio Cloud for <c>customdata</c>.
         /// </summary>
         [JsonPropertyName(@"customdatasrc")]
         public string CustomDataSrc { get; set;} 
@@ -104,7 +104,7 @@ namespace Plotly.Blazor.Traces
         public IList<Plotly.Blazor.Traces.DensityMapBoxLib.HoverInfoFlag?> HoverInfoArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  hoverinfo .
+        ///     Sets the source reference on Chart Studio Cloud for <c>hoverinfo</c>.
         /// </summary>
         [JsonPropertyName(@"hoverinfosrc")]
         public string HoverInfoSrc { get; set;} 
@@ -165,7 +165,7 @@ namespace Plotly.Blazor.Traces
         public IList<string> HoverTemplateArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  hovertemplate .
+        ///     Sets the source reference on Chart Studio Cloud for <c>hovertemplate</c>.
         /// </summary>
         [JsonPropertyName(@"hovertemplatesrc")]
         public string HoverTemplateSrc { get; set;} 
@@ -192,7 +192,7 @@ namespace Plotly.Blazor.Traces
         public IList<string> HoverTextArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  hovertext .
+        ///     Sets the source reference on Chart Studio Cloud for <c>hovertext</c>.
         /// </summary>
         [JsonPropertyName(@"hovertextsrc")]
         public string HoverTextSrc { get; set;} 
@@ -206,7 +206,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> Ids { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  ids .
+        ///     Sets the source reference on Chart Studio Cloud for <c>ids</c>.
         /// </summary>
         [JsonPropertyName(@"idssrc")]
         public string IdsSrc { get; set;} 
@@ -218,7 +218,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> Lat { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  lat .
+        ///     Sets the source reference on Chart Studio Cloud for <c>lat</c>.
         /// </summary>
         [JsonPropertyName(@"latsrc")]
         public string LatSrc { get; set;} 
@@ -253,7 +253,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> Lon { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  lon .
+        ///     Sets the source reference on Chart Studio Cloud for <c>lon</c>.
         /// </summary>
         [JsonPropertyName(@"lonsrc")]
         public string LonSrc { get; set;} 
@@ -288,7 +288,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> MetaArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  meta .
+        ///     Sets the source reference on Chart Studio Cloud for <c>meta</c>.
         /// </summary>
         [JsonPropertyName(@"metasrc")]
         public string MetaSrc { get; set;} 
@@ -321,7 +321,7 @@ namespace Plotly.Blazor.Traces
         public IList<decimal?> RadiusArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  radius .
+        ///     Sets the source reference on Chart Studio Cloud for <c>radius</c>.
         /// </summary>
         [JsonPropertyName(@"radiussrc")]
         public string RadiusSrc { get; set;} 
@@ -383,7 +383,7 @@ namespace Plotly.Blazor.Traces
         public IList<string> TextArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  text .
+        ///     Sets the source reference on Chart Studio Cloud for <c>text</c>.
         /// </summary>
         [JsonPropertyName(@"textsrc")]
         public string TextSrc { get; set;} 
@@ -465,7 +465,7 @@ namespace Plotly.Blazor.Traces
         public decimal? ZMin { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  z .
+        ///     Sets the source reference on Chart Studio Cloud for <c>z</c>.
         /// </summary>
         [JsonPropertyName(@"zsrc")]
         public string ZSrc { get; set;} 

--- a/Plotly.Blazor/Traces/DensityMapBoxLib/HoverLabel.cs
+++ b/Plotly.Blazor/Traces/DensityMapBoxLib/HoverLabel.cs
@@ -36,7 +36,7 @@ namespace Plotly.Blazor.Traces.DensityMapBoxLib
         public IList<Plotly.Blazor.Traces.DensityMapBoxLib.HoverLabelLib.AlignEnum?> AlignArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  align .
+        ///     Sets the source reference on Chart Studio Cloud for <c>align</c>.
         /// </summary>
         [JsonPropertyName(@"alignsrc")]
         public string AlignSrc { get; set;} 
@@ -55,7 +55,7 @@ namespace Plotly.Blazor.Traces.DensityMapBoxLib
         public IList<object> BgColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  bgcolor .
+        ///     Sets the source reference on Chart Studio Cloud for <c>bgcolor</c>.
         /// </summary>
         [JsonPropertyName(@"bgcolorsrc")]
         public string BgColorSrc { get; set;} 
@@ -74,7 +74,7 @@ namespace Plotly.Blazor.Traces.DensityMapBoxLib
         public IList<object> BorderColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  bordercolor .
+        ///     Sets the source reference on Chart Studio Cloud for <c>bordercolor</c>.
         /// </summary>
         [JsonPropertyName(@"bordercolorsrc")]
         public string BorderColorSrc { get; set;} 
@@ -107,7 +107,7 @@ namespace Plotly.Blazor.Traces.DensityMapBoxLib
         public IList<int?> NameLengthArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  namelength .
+        ///     Sets the source reference on Chart Studio Cloud for <c>namelength</c>.
         /// </summary>
         [JsonPropertyName(@"namelengthsrc")]
         public string NameLengthSrc { get; set;} 

--- a/Plotly.Blazor/Traces/DensityMapBoxLib/HoverLabelLib/Font.cs
+++ b/Plotly.Blazor/Traces/DensityMapBoxLib/HoverLabelLib/Font.cs
@@ -34,7 +34,7 @@ namespace Plotly.Blazor.Traces.DensityMapBoxLib.HoverLabelLib
         public IList<object> ColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  color .
+        ///     Sets the source reference on Chart Studio Cloud for <c>color</c>.
         /// </summary>
         [JsonPropertyName(@"colorsrc")]
         public string ColorSrc { get; set;} 
@@ -73,7 +73,7 @@ namespace Plotly.Blazor.Traces.DensityMapBoxLib.HoverLabelLib
         public IList<string> FamilyArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  family .
+        ///     Sets the source reference on Chart Studio Cloud for <c>family</c>.
         /// </summary>
         [JsonPropertyName(@"familysrc")]
         public string FamilySrc { get; set;} 
@@ -92,7 +92,7 @@ namespace Plotly.Blazor.Traces.DensityMapBoxLib.HoverLabelLib
         public IList<decimal?> SizeArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  size .
+        ///     Sets the source reference on Chart Studio Cloud for <c>size</c>.
         /// </summary>
         [JsonPropertyName(@"sizesrc")]
         public string SizeSrc { get; set;} 

--- a/Plotly.Blazor/Traces/Funnel.cs
+++ b/Plotly.Blazor/Traces/Funnel.cs
@@ -63,7 +63,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> CustomData { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  customdata .
+        ///     Sets the source reference on Chart Studio Cloud for <c>customdata</c>.
         /// </summary>
         [JsonPropertyName(@"customdatasrc")]
         public string CustomDataSrc { get; set;} 
@@ -98,7 +98,7 @@ namespace Plotly.Blazor.Traces
         public IList<Plotly.Blazor.Traces.FunnelLib.HoverInfoFlag?> HoverInfoArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  hoverinfo .
+        ///     Sets the source reference on Chart Studio Cloud for <c>hoverinfo</c>.
         /// </summary>
         [JsonPropertyName(@"hoverinfosrc")]
         public string HoverInfoSrc { get; set;} 
@@ -159,7 +159,7 @@ namespace Plotly.Blazor.Traces
         public IList<string> HoverTemplateArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  hovertemplate .
+        ///     Sets the source reference on Chart Studio Cloud for <c>hovertemplate</c>.
         /// </summary>
         [JsonPropertyName(@"hovertemplatesrc")]
         public string HoverTemplateSrc { get; set;} 
@@ -184,7 +184,7 @@ namespace Plotly.Blazor.Traces
         public IList<string> HoverTextArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  hovertext .
+        ///     Sets the source reference on Chart Studio Cloud for <c>hovertext</c>.
         /// </summary>
         [JsonPropertyName(@"hovertextsrc")]
         public string HoverTextSrc { get; set;} 
@@ -198,7 +198,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> Ids { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  ids .
+        ///     Sets the source reference on Chart Studio Cloud for <c>ids</c>.
         /// </summary>
         [JsonPropertyName(@"idssrc")]
         public string IdsSrc { get; set;} 
@@ -275,7 +275,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> MetaArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  meta .
+        ///     Sets the source reference on Chart Studio Cloud for <c>meta</c>.
         /// </summary>
         [JsonPropertyName(@"metasrc")]
         public string MetaSrc { get; set;} 
@@ -417,13 +417,13 @@ namespace Plotly.Blazor.Traces
         public IList<Plotly.Blazor.Traces.FunnelLib.TextPositionEnum?> TextPositionArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  textposition .
+        ///     Sets the source reference on Chart Studio Cloud for <c>textposition</c>.
         /// </summary>
         [JsonPropertyName(@"textpositionsrc")]
         public string TextPositionSrc { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  text .
+        ///     Sets the source reference on Chart Studio Cloud for <c>text</c>.
         /// </summary>
         [JsonPropertyName(@"textsrc")]
         public string TextSrc { get; set;} 
@@ -462,7 +462,7 @@ namespace Plotly.Blazor.Traces
         public IList<string> TextTemplateArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  texttemplate .
+        ///     Sets the source reference on Chart Studio Cloud for <c>texttemplate</c>.
         /// </summary>
         [JsonPropertyName(@"texttemplatesrc")]
         public string TextTemplateSrc { get; set;} 
@@ -571,7 +571,7 @@ namespace Plotly.Blazor.Traces
         public Plotly.Blazor.Traces.FunnelLib.XPeriodAlignmentEnum? XPeriodAlignment { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  x .
+        ///     Sets the source reference on Chart Studio Cloud for <c>x</c>.
         /// </summary>
         [JsonPropertyName(@"xsrc")]
         public string XSrc { get; set;} 
@@ -636,7 +636,7 @@ namespace Plotly.Blazor.Traces
         public Plotly.Blazor.Traces.FunnelLib.YPeriodAlignmentEnum? YPeriodAlignment { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  y .
+        ///     Sets the source reference on Chart Studio Cloud for <c>y</c>.
         /// </summary>
         [JsonPropertyName(@"ysrc")]
         public string YSrc { get; set;} 

--- a/Plotly.Blazor/Traces/FunnelArea.cs
+++ b/Plotly.Blazor/Traces/FunnelArea.cs
@@ -46,7 +46,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> CustomData { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  customdata .
+        ///     Sets the source reference on Chart Studio Cloud for <c>customdata</c>.
         /// </summary>
         [JsonPropertyName(@"customdatasrc")]
         public string CustomDataSrc { get; set;} 
@@ -81,7 +81,7 @@ namespace Plotly.Blazor.Traces
         public IList<Plotly.Blazor.Traces.FunnelAreaLib.HoverInfoFlag?> HoverInfoArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  hoverinfo .
+        ///     Sets the source reference on Chart Studio Cloud for <c>hoverinfo</c>.
         /// </summary>
         [JsonPropertyName(@"hoverinfosrc")]
         public string HoverInfoSrc { get; set;} 
@@ -144,7 +144,7 @@ namespace Plotly.Blazor.Traces
         public IList<string> HoverTemplateArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  hovertemplate .
+        ///     Sets the source reference on Chart Studio Cloud for <c>hovertemplate</c>.
         /// </summary>
         [JsonPropertyName(@"hovertemplatesrc")]
         public string HoverTemplateSrc { get; set;} 
@@ -169,7 +169,7 @@ namespace Plotly.Blazor.Traces
         public IList<string> HoverTextArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  hovertext .
+        ///     Sets the source reference on Chart Studio Cloud for <c>hovertext</c>.
         /// </summary>
         [JsonPropertyName(@"hovertextsrc")]
         public string HoverTextSrc { get; set;} 
@@ -183,7 +183,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> Ids { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  ids .
+        ///     Sets the source reference on Chart Studio Cloud for <c>ids</c>.
         /// </summary>
         [JsonPropertyName(@"idssrc")]
         public string IdsSrc { get; set;} 
@@ -211,7 +211,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> Labels { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  labels .
+        ///     Sets the source reference on Chart Studio Cloud for <c>labels</c>.
         /// </summary>
         [JsonPropertyName(@"labelssrc")]
         public string LabelsSrc { get; set;} 
@@ -275,7 +275,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> MetaArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  meta .
+        ///     Sets the source reference on Chart Studio Cloud for <c>meta</c>.
         /// </summary>
         [JsonPropertyName(@"metasrc")]
         public string MetaSrc { get; set;} 
@@ -348,13 +348,13 @@ namespace Plotly.Blazor.Traces
         public IList<Plotly.Blazor.Traces.FunnelAreaLib.TextPositionEnum?> TextPositionArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  textposition .
+        ///     Sets the source reference on Chart Studio Cloud for <c>textposition</c>.
         /// </summary>
         [JsonPropertyName(@"textpositionsrc")]
         public string TextPositionSrc { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  text .
+        ///     Sets the source reference on Chart Studio Cloud for <c>text</c>.
         /// </summary>
         [JsonPropertyName(@"textsrc")]
         public string TextSrc { get; set;} 
@@ -393,7 +393,7 @@ namespace Plotly.Blazor.Traces
         public IList<string> TextTemplateArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  texttemplate .
+        ///     Sets the source reference on Chart Studio Cloud for <c>texttemplate</c>.
         /// </summary>
         [JsonPropertyName(@"texttemplatesrc")]
         public string TextTemplateSrc { get; set;} 
@@ -442,7 +442,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> Values { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  values .
+        ///     Sets the source reference on Chart Studio Cloud for <c>values</c>.
         /// </summary>
         [JsonPropertyName(@"valuessrc")]
         public string ValuesSrc { get; set;} 

--- a/Plotly.Blazor/Traces/FunnelAreaLib/HoverLabel.cs
+++ b/Plotly.Blazor/Traces/FunnelAreaLib/HoverLabel.cs
@@ -36,7 +36,7 @@ namespace Plotly.Blazor.Traces.FunnelAreaLib
         public IList<Plotly.Blazor.Traces.FunnelAreaLib.HoverLabelLib.AlignEnum?> AlignArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  align .
+        ///     Sets the source reference on Chart Studio Cloud for <c>align</c>.
         /// </summary>
         [JsonPropertyName(@"alignsrc")]
         public string AlignSrc { get; set;} 
@@ -55,7 +55,7 @@ namespace Plotly.Blazor.Traces.FunnelAreaLib
         public IList<object> BgColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  bgcolor .
+        ///     Sets the source reference on Chart Studio Cloud for <c>bgcolor</c>.
         /// </summary>
         [JsonPropertyName(@"bgcolorsrc")]
         public string BgColorSrc { get; set;} 
@@ -74,7 +74,7 @@ namespace Plotly.Blazor.Traces.FunnelAreaLib
         public IList<object> BorderColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  bordercolor .
+        ///     Sets the source reference on Chart Studio Cloud for <c>bordercolor</c>.
         /// </summary>
         [JsonPropertyName(@"bordercolorsrc")]
         public string BorderColorSrc { get; set;} 
@@ -107,7 +107,7 @@ namespace Plotly.Blazor.Traces.FunnelAreaLib
         public IList<int?> NameLengthArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  namelength .
+        ///     Sets the source reference on Chart Studio Cloud for <c>namelength</c>.
         /// </summary>
         [JsonPropertyName(@"namelengthsrc")]
         public string NameLengthSrc { get; set;} 

--- a/Plotly.Blazor/Traces/FunnelAreaLib/HoverLabelLib/Font.cs
+++ b/Plotly.Blazor/Traces/FunnelAreaLib/HoverLabelLib/Font.cs
@@ -34,7 +34,7 @@ namespace Plotly.Blazor.Traces.FunnelAreaLib.HoverLabelLib
         public IList<object> ColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  color .
+        ///     Sets the source reference on Chart Studio Cloud for <c>color</c>.
         /// </summary>
         [JsonPropertyName(@"colorsrc")]
         public string ColorSrc { get; set;} 
@@ -73,7 +73,7 @@ namespace Plotly.Blazor.Traces.FunnelAreaLib.HoverLabelLib
         public IList<string> FamilyArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  family .
+        ///     Sets the source reference on Chart Studio Cloud for <c>family</c>.
         /// </summary>
         [JsonPropertyName(@"familysrc")]
         public string FamilySrc { get; set;} 
@@ -92,7 +92,7 @@ namespace Plotly.Blazor.Traces.FunnelAreaLib.HoverLabelLib
         public IList<decimal?> SizeArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  size .
+        ///     Sets the source reference on Chart Studio Cloud for <c>size</c>.
         /// </summary>
         [JsonPropertyName(@"sizesrc")]
         public string SizeSrc { get; set;} 

--- a/Plotly.Blazor/Traces/FunnelAreaLib/InsideTextFont.cs
+++ b/Plotly.Blazor/Traces/FunnelAreaLib/InsideTextFont.cs
@@ -34,7 +34,7 @@ namespace Plotly.Blazor.Traces.FunnelAreaLib
         public IList<object> ColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  color .
+        ///     Sets the source reference on Chart Studio Cloud for <c>color</c>.
         /// </summary>
         [JsonPropertyName(@"colorsrc")]
         public string ColorSrc { get; set;} 
@@ -73,7 +73,7 @@ namespace Plotly.Blazor.Traces.FunnelAreaLib
         public IList<string> FamilyArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  family .
+        ///     Sets the source reference on Chart Studio Cloud for <c>family</c>.
         /// </summary>
         [JsonPropertyName(@"familysrc")]
         public string FamilySrc { get; set;} 
@@ -92,7 +92,7 @@ namespace Plotly.Blazor.Traces.FunnelAreaLib
         public IList<decimal?> SizeArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  size .
+        ///     Sets the source reference on Chart Studio Cloud for <c>size</c>.
         /// </summary>
         [JsonPropertyName(@"sizesrc")]
         public string SizeSrc { get; set;} 

--- a/Plotly.Blazor/Traces/FunnelAreaLib/Marker.cs
+++ b/Plotly.Blazor/Traces/FunnelAreaLib/Marker.cs
@@ -27,7 +27,7 @@ namespace Plotly.Blazor.Traces.FunnelAreaLib
         public IList<object> Colors { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  colors .
+        ///     Sets the source reference on Chart Studio Cloud for <c>colors</c>.
         /// </summary>
         [JsonPropertyName(@"colorssrc")]
         public string ColorsSrc { get; set;} 

--- a/Plotly.Blazor/Traces/FunnelAreaLib/MarkerLib/Line.cs
+++ b/Plotly.Blazor/Traces/FunnelAreaLib/MarkerLib/Line.cs
@@ -36,7 +36,7 @@ namespace Plotly.Blazor.Traces.FunnelAreaLib.MarkerLib
         public IList<object> ColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  color .
+        ///     Sets the source reference on Chart Studio Cloud for <c>color</c>.
         /// </summary>
         [JsonPropertyName(@"colorsrc")]
         public string ColorSrc { get; set;} 
@@ -55,7 +55,7 @@ namespace Plotly.Blazor.Traces.FunnelAreaLib.MarkerLib
         public IList<decimal?> WidthArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  width .
+        ///     Sets the source reference on Chart Studio Cloud for <c>width</c>.
         /// </summary>
         [JsonPropertyName(@"widthsrc")]
         public string WidthSrc { get; set;} 

--- a/Plotly.Blazor/Traces/FunnelAreaLib/TextFont.cs
+++ b/Plotly.Blazor/Traces/FunnelAreaLib/TextFont.cs
@@ -34,7 +34,7 @@ namespace Plotly.Blazor.Traces.FunnelAreaLib
         public IList<object> ColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  color .
+        ///     Sets the source reference on Chart Studio Cloud for <c>color</c>.
         /// </summary>
         [JsonPropertyName(@"colorsrc")]
         public string ColorSrc { get; set;} 
@@ -73,7 +73,7 @@ namespace Plotly.Blazor.Traces.FunnelAreaLib
         public IList<string> FamilyArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  family .
+        ///     Sets the source reference on Chart Studio Cloud for <c>family</c>.
         /// </summary>
         [JsonPropertyName(@"familysrc")]
         public string FamilySrc { get; set;} 
@@ -92,7 +92,7 @@ namespace Plotly.Blazor.Traces.FunnelAreaLib
         public IList<decimal?> SizeArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  size .
+        ///     Sets the source reference on Chart Studio Cloud for <c>size</c>.
         /// </summary>
         [JsonPropertyName(@"sizesrc")]
         public string SizeSrc { get; set;} 

--- a/Plotly.Blazor/Traces/FunnelAreaLib/TitleLib/Font.cs
+++ b/Plotly.Blazor/Traces/FunnelAreaLib/TitleLib/Font.cs
@@ -34,7 +34,7 @@ namespace Plotly.Blazor.Traces.FunnelAreaLib.TitleLib
         public IList<object> ColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  color .
+        ///     Sets the source reference on Chart Studio Cloud for <c>color</c>.
         /// </summary>
         [JsonPropertyName(@"colorsrc")]
         public string ColorSrc { get; set;} 
@@ -73,7 +73,7 @@ namespace Plotly.Blazor.Traces.FunnelAreaLib.TitleLib
         public IList<string> FamilyArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  family .
+        ///     Sets the source reference on Chart Studio Cloud for <c>family</c>.
         /// </summary>
         [JsonPropertyName(@"familysrc")]
         public string FamilySrc { get; set;} 
@@ -92,7 +92,7 @@ namespace Plotly.Blazor.Traces.FunnelAreaLib.TitleLib
         public IList<decimal?> SizeArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  size .
+        ///     Sets the source reference on Chart Studio Cloud for <c>size</c>.
         /// </summary>
         [JsonPropertyName(@"sizesrc")]
         public string SizeSrc { get; set;} 

--- a/Plotly.Blazor/Traces/FunnelLib/HoverLabel.cs
+++ b/Plotly.Blazor/Traces/FunnelLib/HoverLabel.cs
@@ -36,7 +36,7 @@ namespace Plotly.Blazor.Traces.FunnelLib
         public IList<Plotly.Blazor.Traces.FunnelLib.HoverLabelLib.AlignEnum?> AlignArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  align .
+        ///     Sets the source reference on Chart Studio Cloud for <c>align</c>.
         /// </summary>
         [JsonPropertyName(@"alignsrc")]
         public string AlignSrc { get; set;} 
@@ -55,7 +55,7 @@ namespace Plotly.Blazor.Traces.FunnelLib
         public IList<object> BgColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  bgcolor .
+        ///     Sets the source reference on Chart Studio Cloud for <c>bgcolor</c>.
         /// </summary>
         [JsonPropertyName(@"bgcolorsrc")]
         public string BgColorSrc { get; set;} 
@@ -74,7 +74,7 @@ namespace Plotly.Blazor.Traces.FunnelLib
         public IList<object> BorderColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  bordercolor .
+        ///     Sets the source reference on Chart Studio Cloud for <c>bordercolor</c>.
         /// </summary>
         [JsonPropertyName(@"bordercolorsrc")]
         public string BorderColorSrc { get; set;} 
@@ -107,7 +107,7 @@ namespace Plotly.Blazor.Traces.FunnelLib
         public IList<int?> NameLengthArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  namelength .
+        ///     Sets the source reference on Chart Studio Cloud for <c>namelength</c>.
         /// </summary>
         [JsonPropertyName(@"namelengthsrc")]
         public string NameLengthSrc { get; set;} 

--- a/Plotly.Blazor/Traces/FunnelLib/HoverLabelLib/Font.cs
+++ b/Plotly.Blazor/Traces/FunnelLib/HoverLabelLib/Font.cs
@@ -34,7 +34,7 @@ namespace Plotly.Blazor.Traces.FunnelLib.HoverLabelLib
         public IList<object> ColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  color .
+        ///     Sets the source reference on Chart Studio Cloud for <c>color</c>.
         /// </summary>
         [JsonPropertyName(@"colorsrc")]
         public string ColorSrc { get; set;} 
@@ -73,7 +73,7 @@ namespace Plotly.Blazor.Traces.FunnelLib.HoverLabelLib
         public IList<string> FamilyArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  family .
+        ///     Sets the source reference on Chart Studio Cloud for <c>family</c>.
         /// </summary>
         [JsonPropertyName(@"familysrc")]
         public string FamilySrc { get; set;} 
@@ -92,7 +92,7 @@ namespace Plotly.Blazor.Traces.FunnelLib.HoverLabelLib
         public IList<decimal?> SizeArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  size .
+        ///     Sets the source reference on Chart Studio Cloud for <c>size</c>.
         /// </summary>
         [JsonPropertyName(@"sizesrc")]
         public string SizeSrc { get; set;} 

--- a/Plotly.Blazor/Traces/FunnelLib/InsideTextFont.cs
+++ b/Plotly.Blazor/Traces/FunnelLib/InsideTextFont.cs
@@ -34,7 +34,7 @@ namespace Plotly.Blazor.Traces.FunnelLib
         public IList<object> ColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  color .
+        ///     Sets the source reference on Chart Studio Cloud for <c>color</c>.
         /// </summary>
         [JsonPropertyName(@"colorsrc")]
         public string ColorSrc { get; set;} 
@@ -73,7 +73,7 @@ namespace Plotly.Blazor.Traces.FunnelLib
         public IList<string> FamilyArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  family .
+        ///     Sets the source reference on Chart Studio Cloud for <c>family</c>.
         /// </summary>
         [JsonPropertyName(@"familysrc")]
         public string FamilySrc { get; set;} 
@@ -92,7 +92,7 @@ namespace Plotly.Blazor.Traces.FunnelLib
         public IList<decimal?> SizeArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  size .
+        ///     Sets the source reference on Chart Studio Cloud for <c>size</c>.
         /// </summary>
         [JsonPropertyName(@"sizesrc")]
         public string SizeSrc { get; set;} 

--- a/Plotly.Blazor/Traces/FunnelLib/Marker.cs
+++ b/Plotly.Blazor/Traces/FunnelLib/Marker.cs
@@ -114,7 +114,7 @@ namespace Plotly.Blazor.Traces.FunnelLib
         public object ColorScale { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  color .
+        ///     Sets the source reference on Chart Studio Cloud for <c>color</c>.
         /// </summary>
         [JsonPropertyName(@"colorsrc")]
         public string ColorSrc { get; set;} 
@@ -139,7 +139,7 @@ namespace Plotly.Blazor.Traces.FunnelLib
         public IList<decimal?> OpacityArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  opacity .
+        ///     Sets the source reference on Chart Studio Cloud for <c>opacity</c>.
         /// </summary>
         [JsonPropertyName(@"opacitysrc")]
         public string OpacitySrc { get; set;} 

--- a/Plotly.Blazor/Traces/FunnelLib/MarkerLib/Line.cs
+++ b/Plotly.Blazor/Traces/FunnelLib/MarkerLib/Line.cs
@@ -110,7 +110,7 @@ namespace Plotly.Blazor.Traces.FunnelLib.MarkerLib
         public object ColorScale { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  color .
+        ///     Sets the source reference on Chart Studio Cloud for <c>color</c>.
         /// </summary>
         [JsonPropertyName(@"colorsrc")]
         public string ColorSrc { get; set;} 
@@ -138,7 +138,7 @@ namespace Plotly.Blazor.Traces.FunnelLib.MarkerLib
         public IList<decimal?> WidthArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  width .
+        ///     Sets the source reference on Chart Studio Cloud for <c>width</c>.
         /// </summary>
         [JsonPropertyName(@"widthsrc")]
         public string WidthSrc { get; set;} 

--- a/Plotly.Blazor/Traces/FunnelLib/OutsideTextFont.cs
+++ b/Plotly.Blazor/Traces/FunnelLib/OutsideTextFont.cs
@@ -34,7 +34,7 @@ namespace Plotly.Blazor.Traces.FunnelLib
         public IList<object> ColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  color .
+        ///     Sets the source reference on Chart Studio Cloud for <c>color</c>.
         /// </summary>
         [JsonPropertyName(@"colorsrc")]
         public string ColorSrc { get; set;} 
@@ -73,7 +73,7 @@ namespace Plotly.Blazor.Traces.FunnelLib
         public IList<string> FamilyArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  family .
+        ///     Sets the source reference on Chart Studio Cloud for <c>family</c>.
         /// </summary>
         [JsonPropertyName(@"familysrc")]
         public string FamilySrc { get; set;} 
@@ -92,7 +92,7 @@ namespace Plotly.Blazor.Traces.FunnelLib
         public IList<decimal?> SizeArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  size .
+        ///     Sets the source reference on Chart Studio Cloud for <c>size</c>.
         /// </summary>
         [JsonPropertyName(@"sizesrc")]
         public string SizeSrc { get; set;} 

--- a/Plotly.Blazor/Traces/FunnelLib/TextFont.cs
+++ b/Plotly.Blazor/Traces/FunnelLib/TextFont.cs
@@ -34,7 +34,7 @@ namespace Plotly.Blazor.Traces.FunnelLib
         public IList<object> ColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  color .
+        ///     Sets the source reference on Chart Studio Cloud for <c>color</c>.
         /// </summary>
         [JsonPropertyName(@"colorsrc")]
         public string ColorSrc { get; set;} 
@@ -73,7 +73,7 @@ namespace Plotly.Blazor.Traces.FunnelLib
         public IList<string> FamilyArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  family .
+        ///     Sets the source reference on Chart Studio Cloud for <c>family</c>.
         /// </summary>
         [JsonPropertyName(@"familysrc")]
         public string FamilySrc { get; set;} 
@@ -92,7 +92,7 @@ namespace Plotly.Blazor.Traces.FunnelLib
         public IList<decimal?> SizeArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  size .
+        ///     Sets the source reference on Chart Studio Cloud for <c>size</c>.
         /// </summary>
         [JsonPropertyName(@"sizesrc")]
         public string SizeSrc { get; set;} 

--- a/Plotly.Blazor/Traces/HeatMapGl.cs
+++ b/Plotly.Blazor/Traces/HeatMapGl.cs
@@ -72,7 +72,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> CustomData { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  customdata .
+        ///     Sets the source reference on Chart Studio Cloud for <c>customdata</c>.
         /// </summary>
         [JsonPropertyName(@"customdatasrc")]
         public string CustomDataSrc { get; set;} 
@@ -107,7 +107,7 @@ namespace Plotly.Blazor.Traces
         public IList<Plotly.Blazor.Traces.HeatMapGlLib.HoverInfoFlag?> HoverInfoArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  hoverinfo .
+        ///     Sets the source reference on Chart Studio Cloud for <c>hoverinfo</c>.
         /// </summary>
         [JsonPropertyName(@"hoverinfosrc")]
         public string HoverInfoSrc { get; set;} 
@@ -127,7 +127,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> Ids { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  ids .
+        ///     Sets the source reference on Chart Studio Cloud for <c>ids</c>.
         /// </summary>
         [JsonPropertyName(@"idssrc")]
         public string IdsSrc { get; set;} 
@@ -178,7 +178,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> MetaArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  meta .
+        ///     Sets the source reference on Chart Studio Cloud for <c>meta</c>.
         /// </summary>
         [JsonPropertyName(@"metasrc")]
         public string MetaSrc { get; set;} 
@@ -222,7 +222,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> Text { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  text .
+        ///     Sets the source reference on Chart Studio Cloud for <c>text</c>.
         /// </summary>
         [JsonPropertyName(@"textsrc")]
         public string TextSrc { get; set;} 
@@ -293,7 +293,7 @@ namespace Plotly.Blazor.Traces
         public string XAxis { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  x .
+        ///     Sets the source reference on Chart Studio Cloud for <c>x</c>.
         /// </summary>
         [JsonPropertyName(@"xsrc")]
         public string XSrc { get; set;} 
@@ -329,7 +329,7 @@ namespace Plotly.Blazor.Traces
         public string YAxis { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  y .
+        ///     Sets the source reference on Chart Studio Cloud for <c>y</c>.
         /// </summary>
         [JsonPropertyName(@"ysrc")]
         public string YSrc { get; set;} 
@@ -387,7 +387,7 @@ namespace Plotly.Blazor.Traces
         public Plotly.Blazor.Traces.HeatMapGlLib.ZSmoothEnum? ZSmooth { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  z .
+        ///     Sets the source reference on Chart Studio Cloud for <c>z</c>.
         /// </summary>
         [JsonPropertyName(@"zsrc")]
         public string ZSrc { get; set;} 

--- a/Plotly.Blazor/Traces/HeatMapGlLib/HoverLabel.cs
+++ b/Plotly.Blazor/Traces/HeatMapGlLib/HoverLabel.cs
@@ -36,7 +36,7 @@ namespace Plotly.Blazor.Traces.HeatMapGlLib
         public IList<Plotly.Blazor.Traces.HeatMapGlLib.HoverLabelLib.AlignEnum?> AlignArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  align .
+        ///     Sets the source reference on Chart Studio Cloud for <c>align</c>.
         /// </summary>
         [JsonPropertyName(@"alignsrc")]
         public string AlignSrc { get; set;} 
@@ -55,7 +55,7 @@ namespace Plotly.Blazor.Traces.HeatMapGlLib
         public IList<object> BgColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  bgcolor .
+        ///     Sets the source reference on Chart Studio Cloud for <c>bgcolor</c>.
         /// </summary>
         [JsonPropertyName(@"bgcolorsrc")]
         public string BgColorSrc { get; set;} 
@@ -74,7 +74,7 @@ namespace Plotly.Blazor.Traces.HeatMapGlLib
         public IList<object> BorderColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  bordercolor .
+        ///     Sets the source reference on Chart Studio Cloud for <c>bordercolor</c>.
         /// </summary>
         [JsonPropertyName(@"bordercolorsrc")]
         public string BorderColorSrc { get; set;} 
@@ -107,7 +107,7 @@ namespace Plotly.Blazor.Traces.HeatMapGlLib
         public IList<int?> NameLengthArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  namelength .
+        ///     Sets the source reference on Chart Studio Cloud for <c>namelength</c>.
         /// </summary>
         [JsonPropertyName(@"namelengthsrc")]
         public string NameLengthSrc { get; set;} 

--- a/Plotly.Blazor/Traces/HeatMapGlLib/HoverLabelLib/Font.cs
+++ b/Plotly.Blazor/Traces/HeatMapGlLib/HoverLabelLib/Font.cs
@@ -34,7 +34,7 @@ namespace Plotly.Blazor.Traces.HeatMapGlLib.HoverLabelLib
         public IList<object> ColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  color .
+        ///     Sets the source reference on Chart Studio Cloud for <c>color</c>.
         /// </summary>
         [JsonPropertyName(@"colorsrc")]
         public string ColorSrc { get; set;} 
@@ -73,7 +73,7 @@ namespace Plotly.Blazor.Traces.HeatMapGlLib.HoverLabelLib
         public IList<string> FamilyArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  family .
+        ///     Sets the source reference on Chart Studio Cloud for <c>family</c>.
         /// </summary>
         [JsonPropertyName(@"familysrc")]
         public string FamilySrc { get; set;} 
@@ -92,7 +92,7 @@ namespace Plotly.Blazor.Traces.HeatMapGlLib.HoverLabelLib
         public IList<decimal?> SizeArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  size .
+        ///     Sets the source reference on Chart Studio Cloud for <c>size</c>.
         /// </summary>
         [JsonPropertyName(@"sizesrc")]
         public string SizeSrc { get; set;} 

--- a/Plotly.Blazor/Traces/HeatMapLib/HoverLabel.cs
+++ b/Plotly.Blazor/Traces/HeatMapLib/HoverLabel.cs
@@ -36,7 +36,7 @@ namespace Plotly.Blazor.Traces.HeatMapLib
         public IList<Plotly.Blazor.Traces.HeatMapLib.HoverLabelLib.AlignEnum?> AlignArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  align .
+        ///     Sets the source reference on Chart Studio Cloud for <c>align</c>.
         /// </summary>
         [JsonPropertyName(@"alignsrc")]
         public string AlignSrc { get; set;} 
@@ -55,7 +55,7 @@ namespace Plotly.Blazor.Traces.HeatMapLib
         public IList<object> BgColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  bgcolor .
+        ///     Sets the source reference on Chart Studio Cloud for <c>bgcolor</c>.
         /// </summary>
         [JsonPropertyName(@"bgcolorsrc")]
         public string BgColorSrc { get; set;} 
@@ -74,7 +74,7 @@ namespace Plotly.Blazor.Traces.HeatMapLib
         public IList<object> BorderColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  bordercolor .
+        ///     Sets the source reference on Chart Studio Cloud for <c>bordercolor</c>.
         /// </summary>
         [JsonPropertyName(@"bordercolorsrc")]
         public string BorderColorSrc { get; set;} 
@@ -107,7 +107,7 @@ namespace Plotly.Blazor.Traces.HeatMapLib
         public IList<int?> NameLengthArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  namelength .
+        ///     Sets the source reference on Chart Studio Cloud for <c>namelength</c>.
         /// </summary>
         [JsonPropertyName(@"namelengthsrc")]
         public string NameLengthSrc { get; set;} 

--- a/Plotly.Blazor/Traces/HeatMapLib/HoverLabelLib/Font.cs
+++ b/Plotly.Blazor/Traces/HeatMapLib/HoverLabelLib/Font.cs
@@ -34,7 +34,7 @@ namespace Plotly.Blazor.Traces.HeatMapLib.HoverLabelLib
         public IList<object> ColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  color .
+        ///     Sets the source reference on Chart Studio Cloud for <c>color</c>.
         /// </summary>
         [JsonPropertyName(@"colorsrc")]
         public string ColorSrc { get; set;} 
@@ -73,7 +73,7 @@ namespace Plotly.Blazor.Traces.HeatMapLib.HoverLabelLib
         public IList<string> FamilyArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  family .
+        ///     Sets the source reference on Chart Studio Cloud for <c>family</c>.
         /// </summary>
         [JsonPropertyName(@"familysrc")]
         public string FamilySrc { get; set;} 
@@ -92,7 +92,7 @@ namespace Plotly.Blazor.Traces.HeatMapLib.HoverLabelLib
         public IList<decimal?> SizeArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  size .
+        ///     Sets the source reference on Chart Studio Cloud for <c>size</c>.
         /// </summary>
         [JsonPropertyName(@"sizesrc")]
         public string SizeSrc { get; set;} 

--- a/Plotly.Blazor/Traces/Histogram2DContourLib/HoverLabel.cs
+++ b/Plotly.Blazor/Traces/Histogram2DContourLib/HoverLabel.cs
@@ -36,7 +36,7 @@ namespace Plotly.Blazor.Traces.Histogram2DContourLib
         public IList<Plotly.Blazor.Traces.Histogram2DContourLib.HoverLabelLib.AlignEnum?> AlignArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  align .
+        ///     Sets the source reference on Chart Studio Cloud for <c>align</c>.
         /// </summary>
         [JsonPropertyName(@"alignsrc")]
         public string AlignSrc { get; set;} 
@@ -55,7 +55,7 @@ namespace Plotly.Blazor.Traces.Histogram2DContourLib
         public IList<object> BgColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  bgcolor .
+        ///     Sets the source reference on Chart Studio Cloud for <c>bgcolor</c>.
         /// </summary>
         [JsonPropertyName(@"bgcolorsrc")]
         public string BgColorSrc { get; set;} 
@@ -74,7 +74,7 @@ namespace Plotly.Blazor.Traces.Histogram2DContourLib
         public IList<object> BorderColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  bordercolor .
+        ///     Sets the source reference on Chart Studio Cloud for <c>bordercolor</c>.
         /// </summary>
         [JsonPropertyName(@"bordercolorsrc")]
         public string BorderColorSrc { get; set;} 
@@ -107,7 +107,7 @@ namespace Plotly.Blazor.Traces.Histogram2DContourLib
         public IList<int?> NameLengthArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  namelength .
+        ///     Sets the source reference on Chart Studio Cloud for <c>namelength</c>.
         /// </summary>
         [JsonPropertyName(@"namelengthsrc")]
         public string NameLengthSrc { get; set;} 

--- a/Plotly.Blazor/Traces/Histogram2DContourLib/HoverLabelLib/Font.cs
+++ b/Plotly.Blazor/Traces/Histogram2DContourLib/HoverLabelLib/Font.cs
@@ -34,7 +34,7 @@ namespace Plotly.Blazor.Traces.Histogram2DContourLib.HoverLabelLib
         public IList<object> ColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  color .
+        ///     Sets the source reference on Chart Studio Cloud for <c>color</c>.
         /// </summary>
         [JsonPropertyName(@"colorsrc")]
         public string ColorSrc { get; set;} 
@@ -73,7 +73,7 @@ namespace Plotly.Blazor.Traces.Histogram2DContourLib.HoverLabelLib
         public IList<string> FamilyArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  family .
+        ///     Sets the source reference on Chart Studio Cloud for <c>family</c>.
         /// </summary>
         [JsonPropertyName(@"familysrc")]
         public string FamilySrc { get; set;} 
@@ -92,7 +92,7 @@ namespace Plotly.Blazor.Traces.Histogram2DContourLib.HoverLabelLib
         public IList<decimal?> SizeArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  size .
+        ///     Sets the source reference on Chart Studio Cloud for <c>size</c>.
         /// </summary>
         [JsonPropertyName(@"sizesrc")]
         public string SizeSrc { get; set;} 

--- a/Plotly.Blazor/Traces/Histogram2DContourLib/Marker.cs
+++ b/Plotly.Blazor/Traces/Histogram2DContourLib/Marker.cs
@@ -26,7 +26,7 @@ namespace Plotly.Blazor.Traces.Histogram2DContourLib
         public IList<object> Color { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  color .
+        ///     Sets the source reference on Chart Studio Cloud for <c>color</c>.
         /// </summary>
         [JsonPropertyName(@"colorsrc")]
         public string ColorSrc { get; set;} 

--- a/Plotly.Blazor/Traces/Histogram2DLib/HoverLabel.cs
+++ b/Plotly.Blazor/Traces/Histogram2DLib/HoverLabel.cs
@@ -36,7 +36,7 @@ namespace Plotly.Blazor.Traces.Histogram2DLib
         public IList<Plotly.Blazor.Traces.Histogram2DLib.HoverLabelLib.AlignEnum?> AlignArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  align .
+        ///     Sets the source reference on Chart Studio Cloud for <c>align</c>.
         /// </summary>
         [JsonPropertyName(@"alignsrc")]
         public string AlignSrc { get; set;} 
@@ -55,7 +55,7 @@ namespace Plotly.Blazor.Traces.Histogram2DLib
         public IList<object> BgColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  bgcolor .
+        ///     Sets the source reference on Chart Studio Cloud for <c>bgcolor</c>.
         /// </summary>
         [JsonPropertyName(@"bgcolorsrc")]
         public string BgColorSrc { get; set;} 
@@ -74,7 +74,7 @@ namespace Plotly.Blazor.Traces.Histogram2DLib
         public IList<object> BorderColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  bordercolor .
+        ///     Sets the source reference on Chart Studio Cloud for <c>bordercolor</c>.
         /// </summary>
         [JsonPropertyName(@"bordercolorsrc")]
         public string BorderColorSrc { get; set;} 
@@ -107,7 +107,7 @@ namespace Plotly.Blazor.Traces.Histogram2DLib
         public IList<int?> NameLengthArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  namelength .
+        ///     Sets the source reference on Chart Studio Cloud for <c>namelength</c>.
         /// </summary>
         [JsonPropertyName(@"namelengthsrc")]
         public string NameLengthSrc { get; set;} 

--- a/Plotly.Blazor/Traces/Histogram2DLib/HoverLabelLib/Font.cs
+++ b/Plotly.Blazor/Traces/Histogram2DLib/HoverLabelLib/Font.cs
@@ -34,7 +34,7 @@ namespace Plotly.Blazor.Traces.Histogram2DLib.HoverLabelLib
         public IList<object> ColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  color .
+        ///     Sets the source reference on Chart Studio Cloud for <c>color</c>.
         /// </summary>
         [JsonPropertyName(@"colorsrc")]
         public string ColorSrc { get; set;} 
@@ -73,7 +73,7 @@ namespace Plotly.Blazor.Traces.Histogram2DLib.HoverLabelLib
         public IList<string> FamilyArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  family .
+        ///     Sets the source reference on Chart Studio Cloud for <c>family</c>.
         /// </summary>
         [JsonPropertyName(@"familysrc")]
         public string FamilySrc { get; set;} 
@@ -92,7 +92,7 @@ namespace Plotly.Blazor.Traces.Histogram2DLib.HoverLabelLib
         public IList<decimal?> SizeArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  size .
+        ///     Sets the source reference on Chart Studio Cloud for <c>size</c>.
         /// </summary>
         [JsonPropertyName(@"sizesrc")]
         public string SizeSrc { get; set;} 

--- a/Plotly.Blazor/Traces/Histogram2DLib/Marker.cs
+++ b/Plotly.Blazor/Traces/Histogram2DLib/Marker.cs
@@ -26,7 +26,7 @@ namespace Plotly.Blazor.Traces.Histogram2DLib
         public IList<object> Color { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  color .
+        ///     Sets the source reference on Chart Studio Cloud for <c>color</c>.
         /// </summary>
         [JsonPropertyName(@"colorsrc")]
         public string ColorSrc { get; set;} 

--- a/Plotly.Blazor/Traces/HistogramLib/ErrorX.cs
+++ b/Plotly.Blazor/Traces/HistogramLib/ErrorX.cs
@@ -35,13 +35,13 @@ namespace Plotly.Blazor.Traces.HistogramLib
         public IList<object> ArrayMinus { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  arrayminus .
+        ///     Sets the source reference on Chart Studio Cloud for <c>arrayminus</c>.
         /// </summary>
         [JsonPropertyName(@"arrayminussrc")]
         public string ArrayMinusSrc { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  array .
+        ///     Sets the source reference on Chart Studio Cloud for <c>array</c>.
         /// </summary>
         [JsonPropertyName(@"arraysrc")]
         public string ArraySrc { get; set;} 

--- a/Plotly.Blazor/Traces/HistogramLib/ErrorY.cs
+++ b/Plotly.Blazor/Traces/HistogramLib/ErrorY.cs
@@ -35,13 +35,13 @@ namespace Plotly.Blazor.Traces.HistogramLib
         public IList<object> ArrayMinus { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  arrayminus .
+        ///     Sets the source reference on Chart Studio Cloud for <c>arrayminus</c>.
         /// </summary>
         [JsonPropertyName(@"arrayminussrc")]
         public string ArrayMinusSrc { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  array .
+        ///     Sets the source reference on Chart Studio Cloud for <c>array</c>.
         /// </summary>
         [JsonPropertyName(@"arraysrc")]
         public string ArraySrc { get; set;} 

--- a/Plotly.Blazor/Traces/HistogramLib/HoverLabel.cs
+++ b/Plotly.Blazor/Traces/HistogramLib/HoverLabel.cs
@@ -36,7 +36,7 @@ namespace Plotly.Blazor.Traces.HistogramLib
         public IList<Plotly.Blazor.Traces.HistogramLib.HoverLabelLib.AlignEnum?> AlignArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  align .
+        ///     Sets the source reference on Chart Studio Cloud for <c>align</c>.
         /// </summary>
         [JsonPropertyName(@"alignsrc")]
         public string AlignSrc { get; set;} 
@@ -55,7 +55,7 @@ namespace Plotly.Blazor.Traces.HistogramLib
         public IList<object> BgColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  bgcolor .
+        ///     Sets the source reference on Chart Studio Cloud for <c>bgcolor</c>.
         /// </summary>
         [JsonPropertyName(@"bgcolorsrc")]
         public string BgColorSrc { get; set;} 
@@ -74,7 +74,7 @@ namespace Plotly.Blazor.Traces.HistogramLib
         public IList<object> BorderColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  bordercolor .
+        ///     Sets the source reference on Chart Studio Cloud for <c>bordercolor</c>.
         /// </summary>
         [JsonPropertyName(@"bordercolorsrc")]
         public string BorderColorSrc { get; set;} 
@@ -107,7 +107,7 @@ namespace Plotly.Blazor.Traces.HistogramLib
         public IList<int?> NameLengthArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  namelength .
+        ///     Sets the source reference on Chart Studio Cloud for <c>namelength</c>.
         /// </summary>
         [JsonPropertyName(@"namelengthsrc")]
         public string NameLengthSrc { get; set;} 

--- a/Plotly.Blazor/Traces/HistogramLib/HoverLabelLib/Font.cs
+++ b/Plotly.Blazor/Traces/HistogramLib/HoverLabelLib/Font.cs
@@ -34,7 +34,7 @@ namespace Plotly.Blazor.Traces.HistogramLib.HoverLabelLib
         public IList<object> ColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  color .
+        ///     Sets the source reference on Chart Studio Cloud for <c>color</c>.
         /// </summary>
         [JsonPropertyName(@"colorsrc")]
         public string ColorSrc { get; set;} 
@@ -73,7 +73,7 @@ namespace Plotly.Blazor.Traces.HistogramLib.HoverLabelLib
         public IList<string> FamilyArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  family .
+        ///     Sets the source reference on Chart Studio Cloud for <c>family</c>.
         /// </summary>
         [JsonPropertyName(@"familysrc")]
         public string FamilySrc { get; set;} 
@@ -92,7 +92,7 @@ namespace Plotly.Blazor.Traces.HistogramLib.HoverLabelLib
         public IList<decimal?> SizeArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  size .
+        ///     Sets the source reference on Chart Studio Cloud for <c>size</c>.
         /// </summary>
         [JsonPropertyName(@"sizesrc")]
         public string SizeSrc { get; set;} 

--- a/Plotly.Blazor/Traces/HistogramLib/Marker.cs
+++ b/Plotly.Blazor/Traces/HistogramLib/Marker.cs
@@ -114,7 +114,7 @@ namespace Plotly.Blazor.Traces.HistogramLib
         public object ColorScale { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  color .
+        ///     Sets the source reference on Chart Studio Cloud for <c>color</c>.
         /// </summary>
         [JsonPropertyName(@"colorsrc")]
         public string ColorSrc { get; set;} 
@@ -139,7 +139,7 @@ namespace Plotly.Blazor.Traces.HistogramLib
         public IList<decimal?> OpacityArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  opacity .
+        ///     Sets the source reference on Chart Studio Cloud for <c>opacity</c>.
         /// </summary>
         [JsonPropertyName(@"opacitysrc")]
         public string OpacitySrc { get; set;} 

--- a/Plotly.Blazor/Traces/HistogramLib/MarkerLib/Line.cs
+++ b/Plotly.Blazor/Traces/HistogramLib/MarkerLib/Line.cs
@@ -110,7 +110,7 @@ namespace Plotly.Blazor.Traces.HistogramLib.MarkerLib
         public object ColorScale { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  color .
+        ///     Sets the source reference on Chart Studio Cloud for <c>color</c>.
         /// </summary>
         [JsonPropertyName(@"colorsrc")]
         public string ColorSrc { get; set;} 
@@ -138,7 +138,7 @@ namespace Plotly.Blazor.Traces.HistogramLib.MarkerLib
         public IList<decimal?> WidthArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  width .
+        ///     Sets the source reference on Chart Studio Cloud for <c>width</c>.
         /// </summary>
         [JsonPropertyName(@"widthsrc")]
         public string WidthSrc { get; set;} 

--- a/Plotly.Blazor/Traces/Icicle.cs
+++ b/Plotly.Blazor/Traces/Icicle.cs
@@ -51,7 +51,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> CustomData { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  customdata .
+        ///     Sets the source reference on Chart Studio Cloud for <c>customdata</c>.
         /// </summary>
         [JsonPropertyName(@"customdatasrc")]
         public string CustomDataSrc { get; set;} 
@@ -80,7 +80,7 @@ namespace Plotly.Blazor.Traces
         public IList<Plotly.Blazor.Traces.IcicleLib.HoverInfoFlag?> HoverInfoArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  hoverinfo .
+        ///     Sets the source reference on Chart Studio Cloud for <c>hoverinfo</c>.
         /// </summary>
         [JsonPropertyName(@"hoverinfosrc")]
         public string HoverInfoSrc { get; set;} 
@@ -143,7 +143,7 @@ namespace Plotly.Blazor.Traces
         public IList<string> HoverTemplateArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  hovertemplate .
+        ///     Sets the source reference on Chart Studio Cloud for <c>hovertemplate</c>.
         /// </summary>
         [JsonPropertyName(@"hovertemplatesrc")]
         public string HoverTemplateSrc { get; set;} 
@@ -168,7 +168,7 @@ namespace Plotly.Blazor.Traces
         public IList<string> HoverTextArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  hovertext .
+        ///     Sets the source reference on Chart Studio Cloud for <c>hovertext</c>.
         /// </summary>
         [JsonPropertyName(@"hovertextsrc")]
         public string HoverTextSrc { get; set;} 
@@ -182,7 +182,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> Ids { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  ids .
+        ///     Sets the source reference on Chart Studio Cloud for <c>ids</c>.
         /// </summary>
         [JsonPropertyName(@"idssrc")]
         public string IdsSrc { get; set;} 
@@ -200,7 +200,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> Labels { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  labels .
+        ///     Sets the source reference on Chart Studio Cloud for <c>labels</c>.
         /// </summary>
         [JsonPropertyName(@"labelssrc")]
         public string LabelsSrc { get; set;} 
@@ -279,7 +279,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> MetaArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  meta .
+        ///     Sets the source reference on Chart Studio Cloud for <c>meta</c>.
         /// </summary>
         [JsonPropertyName(@"metasrc")]
         public string MetaSrc { get; set;} 
@@ -316,7 +316,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> Parents { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  parents .
+        ///     Sets the source reference on Chart Studio Cloud for <c>parents</c>.
         /// </summary>
         [JsonPropertyName(@"parentssrc")]
         public string ParentsSrc { get; set;} 
@@ -373,7 +373,7 @@ namespace Plotly.Blazor.Traces
         public Plotly.Blazor.Traces.IcicleLib.TextPositionEnum? TextPosition { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  text .
+        ///     Sets the source reference on Chart Studio Cloud for <c>text</c>.
         /// </summary>
         [JsonPropertyName(@"textsrc")]
         public string TextSrc { get; set;} 
@@ -414,7 +414,7 @@ namespace Plotly.Blazor.Traces
         public IList<string> TextTemplateArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  texttemplate .
+        ///     Sets the source reference on Chart Studio Cloud for <c>texttemplate</c>.
         /// </summary>
         [JsonPropertyName(@"texttemplatesrc")]
         public string TextTemplateSrc { get; set;} 
@@ -463,7 +463,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> Values { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  values .
+        ///     Sets the source reference on Chart Studio Cloud for <c>values</c>.
         /// </summary>
         [JsonPropertyName(@"valuessrc")]
         public string ValuesSrc { get; set;} 

--- a/Plotly.Blazor/Traces/IcicleLib/HoverLabel.cs
+++ b/Plotly.Blazor/Traces/IcicleLib/HoverLabel.cs
@@ -36,7 +36,7 @@ namespace Plotly.Blazor.Traces.IcicleLib
         public IList<Plotly.Blazor.Traces.IcicleLib.HoverLabelLib.AlignEnum?> AlignArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  align .
+        ///     Sets the source reference on Chart Studio Cloud for <c>align</c>.
         /// </summary>
         [JsonPropertyName(@"alignsrc")]
         public string AlignSrc { get; set;} 
@@ -55,7 +55,7 @@ namespace Plotly.Blazor.Traces.IcicleLib
         public IList<object> BgColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  bgcolor .
+        ///     Sets the source reference on Chart Studio Cloud for <c>bgcolor</c>.
         /// </summary>
         [JsonPropertyName(@"bgcolorsrc")]
         public string BgColorSrc { get; set;} 
@@ -74,7 +74,7 @@ namespace Plotly.Blazor.Traces.IcicleLib
         public IList<object> BorderColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  bordercolor .
+        ///     Sets the source reference on Chart Studio Cloud for <c>bordercolor</c>.
         /// </summary>
         [JsonPropertyName(@"bordercolorsrc")]
         public string BorderColorSrc { get; set;} 
@@ -107,7 +107,7 @@ namespace Plotly.Blazor.Traces.IcicleLib
         public IList<int?> NameLengthArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  namelength .
+        ///     Sets the source reference on Chart Studio Cloud for <c>namelength</c>.
         /// </summary>
         [JsonPropertyName(@"namelengthsrc")]
         public string NameLengthSrc { get; set;} 

--- a/Plotly.Blazor/Traces/IcicleLib/HoverLabelLib/Font.cs
+++ b/Plotly.Blazor/Traces/IcicleLib/HoverLabelLib/Font.cs
@@ -34,7 +34,7 @@ namespace Plotly.Blazor.Traces.IcicleLib.HoverLabelLib
         public IList<object> ColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  color .
+        ///     Sets the source reference on Chart Studio Cloud for <c>color</c>.
         /// </summary>
         [JsonPropertyName(@"colorsrc")]
         public string ColorSrc { get; set;} 
@@ -73,7 +73,7 @@ namespace Plotly.Blazor.Traces.IcicleLib.HoverLabelLib
         public IList<string> FamilyArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  family .
+        ///     Sets the source reference on Chart Studio Cloud for <c>family</c>.
         /// </summary>
         [JsonPropertyName(@"familysrc")]
         public string FamilySrc { get; set;} 
@@ -92,7 +92,7 @@ namespace Plotly.Blazor.Traces.IcicleLib.HoverLabelLib
         public IList<decimal?> SizeArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  size .
+        ///     Sets the source reference on Chart Studio Cloud for <c>size</c>.
         /// </summary>
         [JsonPropertyName(@"sizesrc")]
         public string SizeSrc { get; set;} 

--- a/Plotly.Blazor/Traces/IcicleLib/InsideTextFont.cs
+++ b/Plotly.Blazor/Traces/IcicleLib/InsideTextFont.cs
@@ -34,7 +34,7 @@ namespace Plotly.Blazor.Traces.IcicleLib
         public IList<object> ColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  color .
+        ///     Sets the source reference on Chart Studio Cloud for <c>color</c>.
         /// </summary>
         [JsonPropertyName(@"colorsrc")]
         public string ColorSrc { get; set;} 
@@ -73,7 +73,7 @@ namespace Plotly.Blazor.Traces.IcicleLib
         public IList<string> FamilyArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  family .
+        ///     Sets the source reference on Chart Studio Cloud for <c>family</c>.
         /// </summary>
         [JsonPropertyName(@"familysrc")]
         public string FamilySrc { get; set;} 
@@ -92,7 +92,7 @@ namespace Plotly.Blazor.Traces.IcicleLib
         public IList<decimal?> SizeArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  size .
+        ///     Sets the source reference on Chart Studio Cloud for <c>size</c>.
         /// </summary>
         [JsonPropertyName(@"sizesrc")]
         public string SizeSrc { get; set;} 

--- a/Plotly.Blazor/Traces/IcicleLib/Marker.cs
+++ b/Plotly.Blazor/Traces/IcicleLib/Marker.cs
@@ -101,7 +101,7 @@ namespace Plotly.Blazor.Traces.IcicleLib
         public object ColorScale { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  colors .
+        ///     Sets the source reference on Chart Studio Cloud for <c>colors</c>.
         /// </summary>
         [JsonPropertyName(@"colorssrc")]
         public string ColorsSrc { get; set;} 

--- a/Plotly.Blazor/Traces/IcicleLib/MarkerLib/Line.cs
+++ b/Plotly.Blazor/Traces/IcicleLib/MarkerLib/Line.cs
@@ -36,7 +36,7 @@ namespace Plotly.Blazor.Traces.IcicleLib.MarkerLib
         public IList<object> ColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  color .
+        ///     Sets the source reference on Chart Studio Cloud for <c>color</c>.
         /// </summary>
         [JsonPropertyName(@"colorsrc")]
         public string ColorSrc { get; set;} 
@@ -55,7 +55,7 @@ namespace Plotly.Blazor.Traces.IcicleLib.MarkerLib
         public IList<decimal?> WidthArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  width .
+        ///     Sets the source reference on Chart Studio Cloud for <c>width</c>.
         /// </summary>
         [JsonPropertyName(@"widthsrc")]
         public string WidthSrc { get; set;} 

--- a/Plotly.Blazor/Traces/IcicleLib/OutsideTextFont.cs
+++ b/Plotly.Blazor/Traces/IcicleLib/OutsideTextFont.cs
@@ -34,7 +34,7 @@ namespace Plotly.Blazor.Traces.IcicleLib
         public IList<object> ColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  color .
+        ///     Sets the source reference on Chart Studio Cloud for <c>color</c>.
         /// </summary>
         [JsonPropertyName(@"colorsrc")]
         public string ColorSrc { get; set;} 
@@ -73,7 +73,7 @@ namespace Plotly.Blazor.Traces.IcicleLib
         public IList<string> FamilyArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  family .
+        ///     Sets the source reference on Chart Studio Cloud for <c>family</c>.
         /// </summary>
         [JsonPropertyName(@"familysrc")]
         public string FamilySrc { get; set;} 
@@ -92,7 +92,7 @@ namespace Plotly.Blazor.Traces.IcicleLib
         public IList<decimal?> SizeArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  size .
+        ///     Sets the source reference on Chart Studio Cloud for <c>size</c>.
         /// </summary>
         [JsonPropertyName(@"sizesrc")]
         public string SizeSrc { get; set;} 

--- a/Plotly.Blazor/Traces/IcicleLib/PathBarLib/TextFont.cs
+++ b/Plotly.Blazor/Traces/IcicleLib/PathBarLib/TextFont.cs
@@ -34,7 +34,7 @@ namespace Plotly.Blazor.Traces.IcicleLib.PathBarLib
         public IList<object> ColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  color .
+        ///     Sets the source reference on Chart Studio Cloud for <c>color</c>.
         /// </summary>
         [JsonPropertyName(@"colorsrc")]
         public string ColorSrc { get; set;} 
@@ -73,7 +73,7 @@ namespace Plotly.Blazor.Traces.IcicleLib.PathBarLib
         public IList<string> FamilyArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  family .
+        ///     Sets the source reference on Chart Studio Cloud for <c>family</c>.
         /// </summary>
         [JsonPropertyName(@"familysrc")]
         public string FamilySrc { get; set;} 
@@ -92,7 +92,7 @@ namespace Plotly.Blazor.Traces.IcicleLib.PathBarLib
         public IList<decimal?> SizeArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  size .
+        ///     Sets the source reference on Chart Studio Cloud for <c>size</c>.
         /// </summary>
         [JsonPropertyName(@"sizesrc")]
         public string SizeSrc { get; set;} 

--- a/Plotly.Blazor/Traces/IcicleLib/TextFont.cs
+++ b/Plotly.Blazor/Traces/IcicleLib/TextFont.cs
@@ -34,7 +34,7 @@ namespace Plotly.Blazor.Traces.IcicleLib
         public IList<object> ColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  color .
+        ///     Sets the source reference on Chart Studio Cloud for <c>color</c>.
         /// </summary>
         [JsonPropertyName(@"colorsrc")]
         public string ColorSrc { get; set;} 
@@ -73,7 +73,7 @@ namespace Plotly.Blazor.Traces.IcicleLib
         public IList<string> FamilyArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  family .
+        ///     Sets the source reference on Chart Studio Cloud for <c>family</c>.
         /// </summary>
         [JsonPropertyName(@"familysrc")]
         public string FamilySrc { get; set;} 
@@ -92,7 +92,7 @@ namespace Plotly.Blazor.Traces.IcicleLib
         public IList<decimal?> SizeArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  size .
+        ///     Sets the source reference on Chart Studio Cloud for <c>size</c>.
         /// </summary>
         [JsonPropertyName(@"sizesrc")]
         public string SizeSrc { get; set;} 

--- a/Plotly.Blazor/Traces/Image.cs
+++ b/Plotly.Blazor/Traces/Image.cs
@@ -42,7 +42,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> CustomData { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  customdata .
+        ///     Sets the source reference on Chart Studio Cloud for <c>customdata</c>.
         /// </summary>
         [JsonPropertyName(@"customdatasrc")]
         public string CustomDataSrc { get; set;} 
@@ -77,7 +77,7 @@ namespace Plotly.Blazor.Traces
         public IList<Plotly.Blazor.Traces.ImageLib.HoverInfoFlag?> HoverInfoArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  hoverinfo .
+        ///     Sets the source reference on Chart Studio Cloud for <c>hoverinfo</c>.
         /// </summary>
         [JsonPropertyName(@"hoverinfosrc")]
         public string HoverInfoSrc { get; set;} 
@@ -138,7 +138,7 @@ namespace Plotly.Blazor.Traces
         public IList<string> HoverTemplateArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  hovertemplate .
+        ///     Sets the source reference on Chart Studio Cloud for <c>hovertemplate</c>.
         /// </summary>
         [JsonPropertyName(@"hovertemplatesrc")]
         public string HoverTemplateSrc { get; set;} 
@@ -150,7 +150,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> HoverText { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  hovertext .
+        ///     Sets the source reference on Chart Studio Cloud for <c>hovertext</c>.
         /// </summary>
         [JsonPropertyName(@"hovertextsrc")]
         public string HoverTextSrc { get; set;} 
@@ -164,7 +164,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> Ids { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  ids .
+        ///     Sets the source reference on Chart Studio Cloud for <c>ids</c>.
         /// </summary>
         [JsonPropertyName(@"idssrc")]
         public string IdsSrc { get; set;} 
@@ -215,7 +215,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> MetaArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  meta .
+        ///     Sets the source reference on Chart Studio Cloud for <c>meta</c>.
         /// </summary>
         [JsonPropertyName(@"metasrc")]
         public string MetaSrc { get; set;} 
@@ -252,7 +252,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> Text { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  text .
+        ///     Sets the source reference on Chart Studio Cloud for <c>text</c>.
         /// </summary>
         [JsonPropertyName(@"textsrc")]
         public string TextSrc { get; set;} 
@@ -353,7 +353,7 @@ namespace Plotly.Blazor.Traces
         public Plotly.Blazor.Traces.ImageLib.ZSmoothEnum? ZSmooth { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  z .
+        ///     Sets the source reference on Chart Studio Cloud for <c>z</c>.
         /// </summary>
         [JsonPropertyName(@"zsrc")]
         public string ZSrc { get; set;} 

--- a/Plotly.Blazor/Traces/ImageLib/HoverLabel.cs
+++ b/Plotly.Blazor/Traces/ImageLib/HoverLabel.cs
@@ -36,7 +36,7 @@ namespace Plotly.Blazor.Traces.ImageLib
         public IList<Plotly.Blazor.Traces.ImageLib.HoverLabelLib.AlignEnum?> AlignArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  align .
+        ///     Sets the source reference on Chart Studio Cloud for <c>align</c>.
         /// </summary>
         [JsonPropertyName(@"alignsrc")]
         public string AlignSrc { get; set;} 
@@ -55,7 +55,7 @@ namespace Plotly.Blazor.Traces.ImageLib
         public IList<object> BgColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  bgcolor .
+        ///     Sets the source reference on Chart Studio Cloud for <c>bgcolor</c>.
         /// </summary>
         [JsonPropertyName(@"bgcolorsrc")]
         public string BgColorSrc { get; set;} 
@@ -74,7 +74,7 @@ namespace Plotly.Blazor.Traces.ImageLib
         public IList<object> BorderColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  bordercolor .
+        ///     Sets the source reference on Chart Studio Cloud for <c>bordercolor</c>.
         /// </summary>
         [JsonPropertyName(@"bordercolorsrc")]
         public string BorderColorSrc { get; set;} 
@@ -107,7 +107,7 @@ namespace Plotly.Blazor.Traces.ImageLib
         public IList<int?> NameLengthArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  namelength .
+        ///     Sets the source reference on Chart Studio Cloud for <c>namelength</c>.
         /// </summary>
         [JsonPropertyName(@"namelengthsrc")]
         public string NameLengthSrc { get; set;} 

--- a/Plotly.Blazor/Traces/ImageLib/HoverLabelLib/Font.cs
+++ b/Plotly.Blazor/Traces/ImageLib/HoverLabelLib/Font.cs
@@ -34,7 +34,7 @@ namespace Plotly.Blazor.Traces.ImageLib.HoverLabelLib
         public IList<object> ColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  color .
+        ///     Sets the source reference on Chart Studio Cloud for <c>color</c>.
         /// </summary>
         [JsonPropertyName(@"colorsrc")]
         public string ColorSrc { get; set;} 
@@ -73,7 +73,7 @@ namespace Plotly.Blazor.Traces.ImageLib.HoverLabelLib
         public IList<string> FamilyArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  family .
+        ///     Sets the source reference on Chart Studio Cloud for <c>family</c>.
         /// </summary>
         [JsonPropertyName(@"familysrc")]
         public string FamilySrc { get; set;} 
@@ -92,7 +92,7 @@ namespace Plotly.Blazor.Traces.ImageLib.HoverLabelLib
         public IList<decimal?> SizeArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  size .
+        ///     Sets the source reference on Chart Studio Cloud for <c>size</c>.
         /// </summary>
         [JsonPropertyName(@"sizesrc")]
         public string SizeSrc { get; set;} 

--- a/Plotly.Blazor/Traces/Indicator.cs
+++ b/Plotly.Blazor/Traces/Indicator.cs
@@ -42,7 +42,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> CustomData { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  customdata .
+        ///     Sets the source reference on Chart Studio Cloud for <c>customdata</c>.
         /// </summary>
         [JsonPropertyName(@"customdatasrc")]
         public string CustomDataSrc { get; set;} 
@@ -74,7 +74,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> Ids { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  ids .
+        ///     Sets the source reference on Chart Studio Cloud for <c>ids</c>.
         /// </summary>
         [JsonPropertyName(@"idssrc")]
         public string IdsSrc { get; set;} 
@@ -125,7 +125,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> MetaArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  meta .
+        ///     Sets the source reference on Chart Studio Cloud for <c>meta</c>.
         /// </summary>
         [JsonPropertyName(@"metasrc")]
         public string MetaSrc { get; set;} 

--- a/Plotly.Blazor/Traces/IsoSurface.cs
+++ b/Plotly.Blazor/Traces/IsoSurface.cs
@@ -115,7 +115,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> CustomData { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  customdata .
+        ///     Sets the source reference on Chart Studio Cloud for <c>customdata</c>.
         /// </summary>
         [JsonPropertyName(@"customdatasrc")]
         public string CustomDataSrc { get; set;} 
@@ -145,7 +145,7 @@ namespace Plotly.Blazor.Traces
         public IList<Plotly.Blazor.Traces.IsoSurfaceLib.HoverInfoFlag?> HoverInfoArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  hoverinfo .
+        ///     Sets the source reference on Chart Studio Cloud for <c>hoverinfo</c>.
         /// </summary>
         [JsonPropertyName(@"hoverinfosrc")]
         public string HoverInfoSrc { get; set;} 
@@ -206,7 +206,7 @@ namespace Plotly.Blazor.Traces
         public IList<string> HoverTemplateArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  hovertemplate .
+        ///     Sets the source reference on Chart Studio Cloud for <c>hovertemplate</c>.
         /// </summary>
         [JsonPropertyName(@"hovertemplatesrc")]
         public string HoverTemplateSrc { get; set;} 
@@ -225,7 +225,7 @@ namespace Plotly.Blazor.Traces
         public IList<string> HoverTextArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  hovertext .
+        ///     Sets the source reference on Chart Studio Cloud for <c>hovertext</c>.
         /// </summary>
         [JsonPropertyName(@"hovertextsrc")]
         public string HoverTextSrc { get; set;} 
@@ -239,7 +239,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> Ids { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  ids .
+        ///     Sets the source reference on Chart Studio Cloud for <c>ids</c>.
         /// </summary>
         [JsonPropertyName(@"idssrc")]
         public string IdsSrc { get; set;} 
@@ -321,7 +321,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> MetaArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  meta .
+        ///     Sets the source reference on Chart Studio Cloud for <c>meta</c>.
         /// </summary>
         [JsonPropertyName(@"metasrc")]
         public string MetaSrc { get; set;} 
@@ -414,7 +414,7 @@ namespace Plotly.Blazor.Traces
         public IList<string> TextArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  text .
+        ///     Sets the source reference on Chart Studio Cloud for <c>text</c>.
         /// </summary>
         [JsonPropertyName(@"textsrc")]
         public string TextSrc { get; set;} 
@@ -459,7 +459,7 @@ namespace Plotly.Blazor.Traces
         public string ValueHoverFormat { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  value .
+        ///     Sets the source reference on Chart Studio Cloud for <c>value</c>.
         /// </summary>
         [JsonPropertyName(@"valuesrc")]
         public string ValueSrc { get; set;} 
@@ -492,7 +492,7 @@ namespace Plotly.Blazor.Traces
         public string XHoverFormat { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  x .
+        ///     Sets the source reference on Chart Studio Cloud for <c>x</c>.
         /// </summary>
         [JsonPropertyName(@"xsrc")]
         public string XSrc { get; set;} 
@@ -517,7 +517,7 @@ namespace Plotly.Blazor.Traces
         public string YHoverFormat { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  y .
+        ///     Sets the source reference on Chart Studio Cloud for <c>y</c>.
         /// </summary>
         [JsonPropertyName(@"ysrc")]
         public string YSrc { get; set;} 
@@ -542,7 +542,7 @@ namespace Plotly.Blazor.Traces
         public string ZHoverFormat { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  z .
+        ///     Sets the source reference on Chart Studio Cloud for <c>z</c>.
         /// </summary>
         [JsonPropertyName(@"zsrc")]
         public string ZSrc { get; set;} 

--- a/Plotly.Blazor/Traces/IsoSurfaceLib/HoverLabel.cs
+++ b/Plotly.Blazor/Traces/IsoSurfaceLib/HoverLabel.cs
@@ -36,7 +36,7 @@ namespace Plotly.Blazor.Traces.IsoSurfaceLib
         public IList<Plotly.Blazor.Traces.IsoSurfaceLib.HoverLabelLib.AlignEnum?> AlignArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  align .
+        ///     Sets the source reference on Chart Studio Cloud for <c>align</c>.
         /// </summary>
         [JsonPropertyName(@"alignsrc")]
         public string AlignSrc { get; set;} 
@@ -55,7 +55,7 @@ namespace Plotly.Blazor.Traces.IsoSurfaceLib
         public IList<object> BgColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  bgcolor .
+        ///     Sets the source reference on Chart Studio Cloud for <c>bgcolor</c>.
         /// </summary>
         [JsonPropertyName(@"bgcolorsrc")]
         public string BgColorSrc { get; set;} 
@@ -74,7 +74,7 @@ namespace Plotly.Blazor.Traces.IsoSurfaceLib
         public IList<object> BorderColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  bordercolor .
+        ///     Sets the source reference on Chart Studio Cloud for <c>bordercolor</c>.
         /// </summary>
         [JsonPropertyName(@"bordercolorsrc")]
         public string BorderColorSrc { get; set;} 
@@ -107,7 +107,7 @@ namespace Plotly.Blazor.Traces.IsoSurfaceLib
         public IList<int?> NameLengthArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  namelength .
+        ///     Sets the source reference on Chart Studio Cloud for <c>namelength</c>.
         /// </summary>
         [JsonPropertyName(@"namelengthsrc")]
         public string NameLengthSrc { get; set;} 

--- a/Plotly.Blazor/Traces/IsoSurfaceLib/HoverLabelLib/Font.cs
+++ b/Plotly.Blazor/Traces/IsoSurfaceLib/HoverLabelLib/Font.cs
@@ -34,7 +34,7 @@ namespace Plotly.Blazor.Traces.IsoSurfaceLib.HoverLabelLib
         public IList<object> ColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  color .
+        ///     Sets the source reference on Chart Studio Cloud for <c>color</c>.
         /// </summary>
         [JsonPropertyName(@"colorsrc")]
         public string ColorSrc { get; set;} 
@@ -73,7 +73,7 @@ namespace Plotly.Blazor.Traces.IsoSurfaceLib.HoverLabelLib
         public IList<string> FamilyArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  family .
+        ///     Sets the source reference on Chart Studio Cloud for <c>family</c>.
         /// </summary>
         [JsonPropertyName(@"familysrc")]
         public string FamilySrc { get; set;} 
@@ -92,7 +92,7 @@ namespace Plotly.Blazor.Traces.IsoSurfaceLib.HoverLabelLib
         public IList<decimal?> SizeArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  size .
+        ///     Sets the source reference on Chart Studio Cloud for <c>size</c>.
         /// </summary>
         [JsonPropertyName(@"sizesrc")]
         public string SizeSrc { get; set;} 

--- a/Plotly.Blazor/Traces/IsoSurfaceLib/SlicesLib/X.cs
+++ b/Plotly.Blazor/Traces/IsoSurfaceLib/SlicesLib/X.cs
@@ -36,7 +36,7 @@ namespace Plotly.Blazor.Traces.IsoSurfaceLib.SlicesLib
         public IList<object> Locations { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  locations .
+        ///     Sets the source reference on Chart Studio Cloud for <c>locations</c>.
         /// </summary>
         [JsonPropertyName(@"locationssrc")]
         public string LocationsSrc { get; set;} 

--- a/Plotly.Blazor/Traces/IsoSurfaceLib/SlicesLib/Y.cs
+++ b/Plotly.Blazor/Traces/IsoSurfaceLib/SlicesLib/Y.cs
@@ -36,7 +36,7 @@ namespace Plotly.Blazor.Traces.IsoSurfaceLib.SlicesLib
         public IList<object> Locations { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  locations .
+        ///     Sets the source reference on Chart Studio Cloud for <c>locations</c>.
         /// </summary>
         [JsonPropertyName(@"locationssrc")]
         public string LocationsSrc { get; set;} 

--- a/Plotly.Blazor/Traces/IsoSurfaceLib/SlicesLib/Z.cs
+++ b/Plotly.Blazor/Traces/IsoSurfaceLib/SlicesLib/Z.cs
@@ -36,7 +36,7 @@ namespace Plotly.Blazor.Traces.IsoSurfaceLib.SlicesLib
         public IList<object> Locations { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  locations .
+        ///     Sets the source reference on Chart Studio Cloud for <c>locations</c>.
         /// </summary>
         [JsonPropertyName(@"locationssrc")]
         public string LocationsSrc { get; set;} 

--- a/Plotly.Blazor/Traces/Mesh3D.cs
+++ b/Plotly.Blazor/Traces/Mesh3D.cs
@@ -134,7 +134,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> CustomData { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  customdata .
+        ///     Sets the source reference on Chart Studio Cloud for <c>customdata</c>.
         /// </summary>
         [JsonPropertyName(@"customdatasrc")]
         public string CustomDataSrc { get; set;} 
@@ -154,7 +154,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> FaceColor { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  facecolor .
+        ///     Sets the source reference on Chart Studio Cloud for <c>facecolor</c>.
         /// </summary>
         [JsonPropertyName(@"facecolorsrc")]
         public string FaceColorSrc { get; set;} 
@@ -184,7 +184,7 @@ namespace Plotly.Blazor.Traces
         public IList<Plotly.Blazor.Traces.Mesh3DLib.HoverInfoFlag?> HoverInfoArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  hoverinfo .
+        ///     Sets the source reference on Chart Studio Cloud for <c>hoverinfo</c>.
         /// </summary>
         [JsonPropertyName(@"hoverinfosrc")]
         public string HoverInfoSrc { get; set;} 
@@ -245,7 +245,7 @@ namespace Plotly.Blazor.Traces
         public IList<string> HoverTemplateArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  hovertemplate .
+        ///     Sets the source reference on Chart Studio Cloud for <c>hovertemplate</c>.
         /// </summary>
         [JsonPropertyName(@"hovertemplatesrc")]
         public string HoverTemplateSrc { get; set;} 
@@ -264,7 +264,7 @@ namespace Plotly.Blazor.Traces
         public IList<string> HoverTextArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  hovertext .
+        ///     Sets the source reference on Chart Studio Cloud for <c>hovertext</c>.
         /// </summary>
         [JsonPropertyName(@"hovertextsrc")]
         public string HoverTextSrc { get; set;} 
@@ -289,7 +289,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> Ids { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  ids .
+        ///     Sets the source reference on Chart Studio Cloud for <c>ids</c>.
         /// </summary>
         [JsonPropertyName(@"idssrc")]
         public string IdsSrc { get; set;} 
@@ -308,13 +308,13 @@ namespace Plotly.Blazor.Traces
         public Plotly.Blazor.Traces.Mesh3DLib.IntensityModeEnum? IntensityMode { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  intensity .
+        ///     Sets the source reference on Chart Studio Cloud for <c>intensity</c>.
         /// </summary>
         [JsonPropertyName(@"intensitysrc")]
         public string IntensitySrc { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  i .
+        ///     Sets the source reference on Chart Studio Cloud for <c>i</c>.
         /// </summary>
         [JsonPropertyName(@"isrc")]
         public string ISrc { get; set;} 
@@ -331,7 +331,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> J { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  j .
+        ///     Sets the source reference on Chart Studio Cloud for <c>j</c>.
         /// </summary>
         [JsonPropertyName(@"jsrc")]
         public string JSrc { get; set;} 
@@ -348,7 +348,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> K { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  k .
+        ///     Sets the source reference on Chart Studio Cloud for <c>k</c>.
         /// </summary>
         [JsonPropertyName(@"ksrc")]
         public string KSrc { get; set;} 
@@ -418,7 +418,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> MetaArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  meta .
+        ///     Sets the source reference on Chart Studio Cloud for <c>meta</c>.
         /// </summary>
         [JsonPropertyName(@"metasrc")]
         public string MetaSrc { get; set;} 
@@ -493,7 +493,7 @@ namespace Plotly.Blazor.Traces
         public IList<string> TextArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  text .
+        ///     Sets the source reference on Chart Studio Cloud for <c>text</c>.
         /// </summary>
         [JsonPropertyName(@"textsrc")]
         public string TextSrc { get; set;} 
@@ -532,7 +532,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> VertexColor { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  vertexcolor .
+        ///     Sets the source reference on Chart Studio Cloud for <c>vertexcolor</c>.
         /// </summary>
         [JsonPropertyName(@"vertexcolorsrc")]
         public string VertexColorSrc { get; set;} 
@@ -573,7 +573,7 @@ namespace Plotly.Blazor.Traces
         public string XHoverFormat { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  x .
+        ///     Sets the source reference on Chart Studio Cloud for <c>x</c>.
         /// </summary>
         [JsonPropertyName(@"xsrc")]
         public string XSrc { get; set;} 
@@ -606,7 +606,7 @@ namespace Plotly.Blazor.Traces
         public string YHoverFormat { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  y .
+        ///     Sets the source reference on Chart Studio Cloud for <c>y</c>.
         /// </summary>
         [JsonPropertyName(@"ysrc")]
         public string YSrc { get; set;} 
@@ -639,7 +639,7 @@ namespace Plotly.Blazor.Traces
         public string ZHoverFormat { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  z .
+        ///     Sets the source reference on Chart Studio Cloud for <c>z</c>.
         /// </summary>
         [JsonPropertyName(@"zsrc")]
         public string ZSrc { get; set;} 

--- a/Plotly.Blazor/Traces/Mesh3DLib/HoverLabel.cs
+++ b/Plotly.Blazor/Traces/Mesh3DLib/HoverLabel.cs
@@ -36,7 +36,7 @@ namespace Plotly.Blazor.Traces.Mesh3DLib
         public IList<Plotly.Blazor.Traces.Mesh3DLib.HoverLabelLib.AlignEnum?> AlignArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  align .
+        ///     Sets the source reference on Chart Studio Cloud for <c>align</c>.
         /// </summary>
         [JsonPropertyName(@"alignsrc")]
         public string AlignSrc { get; set;} 
@@ -55,7 +55,7 @@ namespace Plotly.Blazor.Traces.Mesh3DLib
         public IList<object> BgColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  bgcolor .
+        ///     Sets the source reference on Chart Studio Cloud for <c>bgcolor</c>.
         /// </summary>
         [JsonPropertyName(@"bgcolorsrc")]
         public string BgColorSrc { get; set;} 
@@ -74,7 +74,7 @@ namespace Plotly.Blazor.Traces.Mesh3DLib
         public IList<object> BorderColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  bordercolor .
+        ///     Sets the source reference on Chart Studio Cloud for <c>bordercolor</c>.
         /// </summary>
         [JsonPropertyName(@"bordercolorsrc")]
         public string BorderColorSrc { get; set;} 
@@ -107,7 +107,7 @@ namespace Plotly.Blazor.Traces.Mesh3DLib
         public IList<int?> NameLengthArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  namelength .
+        ///     Sets the source reference on Chart Studio Cloud for <c>namelength</c>.
         /// </summary>
         [JsonPropertyName(@"namelengthsrc")]
         public string NameLengthSrc { get; set;} 

--- a/Plotly.Blazor/Traces/Mesh3DLib/HoverLabelLib/Font.cs
+++ b/Plotly.Blazor/Traces/Mesh3DLib/HoverLabelLib/Font.cs
@@ -34,7 +34,7 @@ namespace Plotly.Blazor.Traces.Mesh3DLib.HoverLabelLib
         public IList<object> ColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  color .
+        ///     Sets the source reference on Chart Studio Cloud for <c>color</c>.
         /// </summary>
         [JsonPropertyName(@"colorsrc")]
         public string ColorSrc { get; set;} 
@@ -73,7 +73,7 @@ namespace Plotly.Blazor.Traces.Mesh3DLib.HoverLabelLib
         public IList<string> FamilyArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  family .
+        ///     Sets the source reference on Chart Studio Cloud for <c>family</c>.
         /// </summary>
         [JsonPropertyName(@"familysrc")]
         public string FamilySrc { get; set;} 
@@ -92,7 +92,7 @@ namespace Plotly.Blazor.Traces.Mesh3DLib.HoverLabelLib
         public IList<decimal?> SizeArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  size .
+        ///     Sets the source reference on Chart Studio Cloud for <c>size</c>.
         /// </summary>
         [JsonPropertyName(@"sizesrc")]
         public string SizeSrc { get; set;} 

--- a/Plotly.Blazor/Traces/Ohlc.cs
+++ b/Plotly.Blazor/Traces/Ohlc.cs
@@ -32,7 +32,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> Close { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  close .
+        ///     Sets the source reference on Chart Studio Cloud for <c>close</c>.
         /// </summary>
         [JsonPropertyName(@"closesrc")]
         public string CloseSrc { get; set;} 
@@ -46,7 +46,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> CustomData { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  customdata .
+        ///     Sets the source reference on Chart Studio Cloud for <c>customdata</c>.
         /// </summary>
         [JsonPropertyName(@"customdatasrc")]
         public string CustomDataSrc { get; set;} 
@@ -64,7 +64,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> High { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  high .
+        ///     Sets the source reference on Chart Studio Cloud for <c>high</c>.
         /// </summary>
         [JsonPropertyName(@"highsrc")]
         public string HighSrc { get; set;} 
@@ -87,7 +87,7 @@ namespace Plotly.Blazor.Traces
         public IList<Plotly.Blazor.Traces.OhlcLib.HoverInfoFlag?> HoverInfoArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  hoverinfo .
+        ///     Sets the source reference on Chart Studio Cloud for <c>hoverinfo</c>.
         /// </summary>
         [JsonPropertyName(@"hoverinfosrc")]
         public string HoverInfoSrc { get; set;} 
@@ -112,7 +112,7 @@ namespace Plotly.Blazor.Traces
         public IList<string> HoverTextArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  hovertext .
+        ///     Sets the source reference on Chart Studio Cloud for <c>hovertext</c>.
         /// </summary>
         [JsonPropertyName(@"hovertextsrc")]
         public string HoverTextSrc { get; set;} 
@@ -126,7 +126,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> Ids { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  ids .
+        ///     Sets the source reference on Chart Studio Cloud for <c>ids</c>.
         /// </summary>
         [JsonPropertyName(@"idssrc")]
         public string IdsSrc { get; set;} 
@@ -173,7 +173,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> Low { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  low .
+        ///     Sets the source reference on Chart Studio Cloud for <c>low</c>.
         /// </summary>
         [JsonPropertyName(@"lowsrc")]
         public string LowSrc { get; set;} 
@@ -208,7 +208,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> MetaArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  meta .
+        ///     Sets the source reference on Chart Studio Cloud for <c>meta</c>.
         /// </summary>
         [JsonPropertyName(@"metasrc")]
         public string MetaSrc { get; set;} 
@@ -232,7 +232,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> Open { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  open .
+        ///     Sets the source reference on Chart Studio Cloud for <c>open</c>.
         /// </summary>
         [JsonPropertyName(@"opensrc")]
         public string OpenSrc { get; set;} 
@@ -278,7 +278,7 @@ namespace Plotly.Blazor.Traces
         public IList<string> TextArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  text .
+        ///     Sets the source reference on Chart Studio Cloud for <c>text</c>.
         /// </summary>
         [JsonPropertyName(@"textsrc")]
         public string TextSrc { get; set;} 
@@ -387,7 +387,7 @@ namespace Plotly.Blazor.Traces
         public Plotly.Blazor.Traces.OhlcLib.XPeriodAlignmentEnum? XPeriodAlignment { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  x .
+        ///     Sets the source reference on Chart Studio Cloud for <c>x</c>.
         /// </summary>
         [JsonPropertyName(@"xsrc")]
         public string XSrc { get; set;} 

--- a/Plotly.Blazor/Traces/OhlcLib/HoverLabel.cs
+++ b/Plotly.Blazor/Traces/OhlcLib/HoverLabel.cs
@@ -36,7 +36,7 @@ namespace Plotly.Blazor.Traces.OhlcLib
         public IList<Plotly.Blazor.Traces.OhlcLib.HoverLabelLib.AlignEnum?> AlignArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  align .
+        ///     Sets the source reference on Chart Studio Cloud for <c>align</c>.
         /// </summary>
         [JsonPropertyName(@"alignsrc")]
         public string AlignSrc { get; set;} 
@@ -55,7 +55,7 @@ namespace Plotly.Blazor.Traces.OhlcLib
         public IList<object> BgColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  bgcolor .
+        ///     Sets the source reference on Chart Studio Cloud for <c>bgcolor</c>.
         /// </summary>
         [JsonPropertyName(@"bgcolorsrc")]
         public string BgColorSrc { get; set;} 
@@ -74,7 +74,7 @@ namespace Plotly.Blazor.Traces.OhlcLib
         public IList<object> BorderColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  bordercolor .
+        ///     Sets the source reference on Chart Studio Cloud for <c>bordercolor</c>.
         /// </summary>
         [JsonPropertyName(@"bordercolorsrc")]
         public string BorderColorSrc { get; set;} 
@@ -107,7 +107,7 @@ namespace Plotly.Blazor.Traces.OhlcLib
         public IList<int?> NameLengthArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  namelength .
+        ///     Sets the source reference on Chart Studio Cloud for <c>namelength</c>.
         /// </summary>
         [JsonPropertyName(@"namelengthsrc")]
         public string NameLengthSrc { get; set;} 

--- a/Plotly.Blazor/Traces/OhlcLib/HoverLabelLib/Font.cs
+++ b/Plotly.Blazor/Traces/OhlcLib/HoverLabelLib/Font.cs
@@ -34,7 +34,7 @@ namespace Plotly.Blazor.Traces.OhlcLib.HoverLabelLib
         public IList<object> ColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  color .
+        ///     Sets the source reference on Chart Studio Cloud for <c>color</c>.
         /// </summary>
         [JsonPropertyName(@"colorsrc")]
         public string ColorSrc { get; set;} 
@@ -73,7 +73,7 @@ namespace Plotly.Blazor.Traces.OhlcLib.HoverLabelLib
         public IList<string> FamilyArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  family .
+        ///     Sets the source reference on Chart Studio Cloud for <c>family</c>.
         /// </summary>
         [JsonPropertyName(@"familysrc")]
         public string FamilySrc { get; set;} 
@@ -92,7 +92,7 @@ namespace Plotly.Blazor.Traces.OhlcLib.HoverLabelLib
         public IList<decimal?> SizeArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  size .
+        ///     Sets the source reference on Chart Studio Cloud for <c>size</c>.
         /// </summary>
         [JsonPropertyName(@"sizesrc")]
         public string SizeSrc { get; set;} 

--- a/Plotly.Blazor/Traces/ParCats.cs
+++ b/Plotly.Blazor/Traces/ParCats.cs
@@ -56,7 +56,7 @@ namespace Plotly.Blazor.Traces
         public IList<decimal?> CountsArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  counts .
+        ///     Sets the source reference on Chart Studio Cloud for <c>counts</c>.
         /// </summary>
         [JsonPropertyName(@"countssrc")]
         public string CountsSrc { get; set;} 
@@ -163,7 +163,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> MetaArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  meta .
+        ///     Sets the source reference on Chart Studio Cloud for <c>meta</c>.
         /// </summary>
         [JsonPropertyName(@"metasrc")]
         public string MetaSrc { get; set;} 

--- a/Plotly.Blazor/Traces/ParCatsLib/Dimension.cs
+++ b/Plotly.Blazor/Traces/ParCatsLib/Dimension.cs
@@ -27,7 +27,7 @@ namespace Plotly.Blazor.Traces.ParCatsLib
         public IList<object> CategoryArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  categoryarray .
+        ///     Sets the source reference on Chart Studio Cloud for <c>categoryarray</c>.
         /// </summary>
         [JsonPropertyName(@"categoryarraysrc")]
         public string CategoryArraySrc { get; set;} 
@@ -68,7 +68,7 @@ namespace Plotly.Blazor.Traces.ParCatsLib
         public IList<object> TickText { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  ticktext .
+        ///     Sets the source reference on Chart Studio Cloud for <c>ticktext</c>.
         /// </summary>
         [JsonPropertyName(@"ticktextsrc")]
         public string TickTextSrc { get; set;} 
@@ -82,7 +82,7 @@ namespace Plotly.Blazor.Traces.ParCatsLib
         public IList<object> Values { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  values .
+        ///     Sets the source reference on Chart Studio Cloud for <c>values</c>.
         /// </summary>
         [JsonPropertyName(@"valuessrc")]
         public string ValuesSrc { get; set;} 

--- a/Plotly.Blazor/Traces/ParCatsLib/Line.cs
+++ b/Plotly.Blazor/Traces/ParCatsLib/Line.cs
@@ -113,7 +113,7 @@ namespace Plotly.Blazor.Traces.ParCatsLib
         public object ColorScale { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  color .
+        ///     Sets the source reference on Chart Studio Cloud for <c>color</c>.
         /// </summary>
         [JsonPropertyName(@"colorsrc")]
         public string ColorSrc { get; set;} 

--- a/Plotly.Blazor/Traces/ParCoords.cs
+++ b/Plotly.Blazor/Traces/ParCoords.cs
@@ -34,7 +34,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> CustomData { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  customdata .
+        ///     Sets the source reference on Chart Studio Cloud for <c>customdata</c>.
         /// </summary>
         [JsonPropertyName(@"customdatasrc")]
         public string CustomDataSrc { get; set;} 
@@ -60,7 +60,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> Ids { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  ids .
+        ///     Sets the source reference on Chart Studio Cloud for <c>ids</c>.
         /// </summary>
         [JsonPropertyName(@"idssrc")]
         public string IdsSrc { get; set;} 
@@ -141,7 +141,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> MetaArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  meta .
+        ///     Sets the source reference on Chart Studio Cloud for <c>meta</c>.
         /// </summary>
         [JsonPropertyName(@"metasrc")]
         public string MetaSrc { get; set;} 

--- a/Plotly.Blazor/Traces/ParCoordsLib/Dimension.cs
+++ b/Plotly.Blazor/Traces/ParCoordsLib/Dimension.cs
@@ -90,7 +90,7 @@ namespace Plotly.Blazor.Traces.ParCoordsLib
         public IList<object> TickText { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  ticktext .
+        ///     Sets the source reference on Chart Studio Cloud for <c>ticktext</c>.
         /// </summary>
         [JsonPropertyName(@"ticktextsrc")]
         public string TickTextSrc { get; set;} 
@@ -102,7 +102,7 @@ namespace Plotly.Blazor.Traces.ParCoordsLib
         public IList<object> TickVals { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  tickvals .
+        ///     Sets the source reference on Chart Studio Cloud for <c>tickvals</c>.
         /// </summary>
         [JsonPropertyName(@"tickvalssrc")]
         public string TickValsSrc { get; set;} 
@@ -117,7 +117,7 @@ namespace Plotly.Blazor.Traces.ParCoordsLib
         public IList<object> Values { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  values .
+        ///     Sets the source reference on Chart Studio Cloud for <c>values</c>.
         /// </summary>
         [JsonPropertyName(@"valuessrc")]
         public string ValuesSrc { get; set;} 

--- a/Plotly.Blazor/Traces/ParCoordsLib/Line.cs
+++ b/Plotly.Blazor/Traces/ParCoordsLib/Line.cs
@@ -113,7 +113,7 @@ namespace Plotly.Blazor.Traces.ParCoordsLib
         public object ColorScale { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  color .
+        ///     Sets the source reference on Chart Studio Cloud for <c>color</c>.
         /// </summary>
         [JsonPropertyName(@"colorsrc")]
         public string ColorSrc { get; set;} 

--- a/Plotly.Blazor/Traces/Pie.cs
+++ b/Plotly.Blazor/Traces/Pie.cs
@@ -40,7 +40,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> CustomData { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  customdata .
+        ///     Sets the source reference on Chart Studio Cloud for <c>customdata</c>.
         /// </summary>
         [JsonPropertyName(@"customdatasrc")]
         public string CustomDataSrc { get; set;} 
@@ -88,7 +88,7 @@ namespace Plotly.Blazor.Traces
         public IList<Plotly.Blazor.Traces.PieLib.HoverInfoFlag?> HoverInfoArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  hoverinfo .
+        ///     Sets the source reference on Chart Studio Cloud for <c>hoverinfo</c>.
         /// </summary>
         [JsonPropertyName(@"hoverinfosrc")]
         public string HoverInfoSrc { get; set;} 
@@ -151,7 +151,7 @@ namespace Plotly.Blazor.Traces
         public IList<string> HoverTemplateArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  hovertemplate .
+        ///     Sets the source reference on Chart Studio Cloud for <c>hovertemplate</c>.
         /// </summary>
         [JsonPropertyName(@"hovertemplatesrc")]
         public string HoverTemplateSrc { get; set;} 
@@ -176,7 +176,7 @@ namespace Plotly.Blazor.Traces
         public IList<string> HoverTextArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  hovertext .
+        ///     Sets the source reference on Chart Studio Cloud for <c>hovertext</c>.
         /// </summary>
         [JsonPropertyName(@"hovertextsrc")]
         public string HoverTextSrc { get; set;} 
@@ -190,7 +190,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> Ids { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  ids .
+        ///     Sets the source reference on Chart Studio Cloud for <c>ids</c>.
         /// </summary>
         [JsonPropertyName(@"idssrc")]
         public string IdsSrc { get; set;} 
@@ -230,7 +230,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> Labels { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  labels .
+        ///     Sets the source reference on Chart Studio Cloud for <c>labels</c>.
         /// </summary>
         [JsonPropertyName(@"labelssrc")]
         public string LabelsSrc { get; set;} 
@@ -294,7 +294,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> MetaArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  meta .
+        ///     Sets the source reference on Chart Studio Cloud for <c>meta</c>.
         /// </summary>
         [JsonPropertyName(@"metasrc")]
         public string MetaSrc { get; set;} 
@@ -335,7 +335,7 @@ namespace Plotly.Blazor.Traces
         public IList<decimal?> PullArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  pull .
+        ///     Sets the source reference on Chart Studio Cloud for <c>pull</c>.
         /// </summary>
         [JsonPropertyName(@"pullsrc")]
         public string PullSrc { get; set;} 
@@ -409,13 +409,13 @@ namespace Plotly.Blazor.Traces
         public IList<Plotly.Blazor.Traces.PieLib.TextPositionEnum?> TextPositionArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  textposition .
+        ///     Sets the source reference on Chart Studio Cloud for <c>textposition</c>.
         /// </summary>
         [JsonPropertyName(@"textpositionsrc")]
         public string TextPositionSrc { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  text .
+        ///     Sets the source reference on Chart Studio Cloud for <c>text</c>.
         /// </summary>
         [JsonPropertyName(@"textsrc")]
         public string TextSrc { get; set;} 
@@ -454,7 +454,7 @@ namespace Plotly.Blazor.Traces
         public IList<string> TextTemplateArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  texttemplate .
+        ///     Sets the source reference on Chart Studio Cloud for <c>texttemplate</c>.
         /// </summary>
         [JsonPropertyName(@"texttemplatesrc")]
         public string TextTemplateSrc { get; set;} 
@@ -503,7 +503,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> Values { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  values .
+        ///     Sets the source reference on Chart Studio Cloud for <c>values</c>.
         /// </summary>
         [JsonPropertyName(@"valuessrc")]
         public string ValuesSrc { get; set;} 

--- a/Plotly.Blazor/Traces/PieLib/HoverLabel.cs
+++ b/Plotly.Blazor/Traces/PieLib/HoverLabel.cs
@@ -36,7 +36,7 @@ namespace Plotly.Blazor.Traces.PieLib
         public IList<Plotly.Blazor.Traces.PieLib.HoverLabelLib.AlignEnum?> AlignArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  align .
+        ///     Sets the source reference on Chart Studio Cloud for <c>align</c>.
         /// </summary>
         [JsonPropertyName(@"alignsrc")]
         public string AlignSrc { get; set;} 
@@ -55,7 +55,7 @@ namespace Plotly.Blazor.Traces.PieLib
         public IList<object> BgColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  bgcolor .
+        ///     Sets the source reference on Chart Studio Cloud for <c>bgcolor</c>.
         /// </summary>
         [JsonPropertyName(@"bgcolorsrc")]
         public string BgColorSrc { get; set;} 
@@ -74,7 +74,7 @@ namespace Plotly.Blazor.Traces.PieLib
         public IList<object> BorderColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  bordercolor .
+        ///     Sets the source reference on Chart Studio Cloud for <c>bordercolor</c>.
         /// </summary>
         [JsonPropertyName(@"bordercolorsrc")]
         public string BorderColorSrc { get; set;} 
@@ -107,7 +107,7 @@ namespace Plotly.Blazor.Traces.PieLib
         public IList<int?> NameLengthArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  namelength .
+        ///     Sets the source reference on Chart Studio Cloud for <c>namelength</c>.
         /// </summary>
         [JsonPropertyName(@"namelengthsrc")]
         public string NameLengthSrc { get; set;} 

--- a/Plotly.Blazor/Traces/PieLib/HoverLabelLib/Font.cs
+++ b/Plotly.Blazor/Traces/PieLib/HoverLabelLib/Font.cs
@@ -34,7 +34,7 @@ namespace Plotly.Blazor.Traces.PieLib.HoverLabelLib
         public IList<object> ColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  color .
+        ///     Sets the source reference on Chart Studio Cloud for <c>color</c>.
         /// </summary>
         [JsonPropertyName(@"colorsrc")]
         public string ColorSrc { get; set;} 
@@ -73,7 +73,7 @@ namespace Plotly.Blazor.Traces.PieLib.HoverLabelLib
         public IList<string> FamilyArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  family .
+        ///     Sets the source reference on Chart Studio Cloud for <c>family</c>.
         /// </summary>
         [JsonPropertyName(@"familysrc")]
         public string FamilySrc { get; set;} 
@@ -92,7 +92,7 @@ namespace Plotly.Blazor.Traces.PieLib.HoverLabelLib
         public IList<decimal?> SizeArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  size .
+        ///     Sets the source reference on Chart Studio Cloud for <c>size</c>.
         /// </summary>
         [JsonPropertyName(@"sizesrc")]
         public string SizeSrc { get; set;} 

--- a/Plotly.Blazor/Traces/PieLib/InsideTextFont.cs
+++ b/Plotly.Blazor/Traces/PieLib/InsideTextFont.cs
@@ -34,7 +34,7 @@ namespace Plotly.Blazor.Traces.PieLib
         public IList<object> ColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  color .
+        ///     Sets the source reference on Chart Studio Cloud for <c>color</c>.
         /// </summary>
         [JsonPropertyName(@"colorsrc")]
         public string ColorSrc { get; set;} 
@@ -73,7 +73,7 @@ namespace Plotly.Blazor.Traces.PieLib
         public IList<string> FamilyArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  family .
+        ///     Sets the source reference on Chart Studio Cloud for <c>family</c>.
         /// </summary>
         [JsonPropertyName(@"familysrc")]
         public string FamilySrc { get; set;} 
@@ -92,7 +92,7 @@ namespace Plotly.Blazor.Traces.PieLib
         public IList<decimal?> SizeArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  size .
+        ///     Sets the source reference on Chart Studio Cloud for <c>size</c>.
         /// </summary>
         [JsonPropertyName(@"sizesrc")]
         public string SizeSrc { get; set;} 

--- a/Plotly.Blazor/Traces/PieLib/Marker.cs
+++ b/Plotly.Blazor/Traces/PieLib/Marker.cs
@@ -27,7 +27,7 @@ namespace Plotly.Blazor.Traces.PieLib
         public IList<object> Colors { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  colors .
+        ///     Sets the source reference on Chart Studio Cloud for <c>colors</c>.
         /// </summary>
         [JsonPropertyName(@"colorssrc")]
         public string ColorsSrc { get; set;} 

--- a/Plotly.Blazor/Traces/PieLib/MarkerLib/Line.cs
+++ b/Plotly.Blazor/Traces/PieLib/MarkerLib/Line.cs
@@ -34,7 +34,7 @@ namespace Plotly.Blazor.Traces.PieLib.MarkerLib
         public IList<object> ColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  color .
+        ///     Sets the source reference on Chart Studio Cloud for <c>color</c>.
         /// </summary>
         [JsonPropertyName(@"colorsrc")]
         public string ColorSrc { get; set;} 
@@ -53,7 +53,7 @@ namespace Plotly.Blazor.Traces.PieLib.MarkerLib
         public IList<decimal?> WidthArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  width .
+        ///     Sets the source reference on Chart Studio Cloud for <c>width</c>.
         /// </summary>
         [JsonPropertyName(@"widthsrc")]
         public string WidthSrc { get; set;} 

--- a/Plotly.Blazor/Traces/PieLib/OutsideTextFont.cs
+++ b/Plotly.Blazor/Traces/PieLib/OutsideTextFont.cs
@@ -34,7 +34,7 @@ namespace Plotly.Blazor.Traces.PieLib
         public IList<object> ColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  color .
+        ///     Sets the source reference on Chart Studio Cloud for <c>color</c>.
         /// </summary>
         [JsonPropertyName(@"colorsrc")]
         public string ColorSrc { get; set;} 
@@ -73,7 +73,7 @@ namespace Plotly.Blazor.Traces.PieLib
         public IList<string> FamilyArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  family .
+        ///     Sets the source reference on Chart Studio Cloud for <c>family</c>.
         /// </summary>
         [JsonPropertyName(@"familysrc")]
         public string FamilySrc { get; set;} 
@@ -92,7 +92,7 @@ namespace Plotly.Blazor.Traces.PieLib
         public IList<decimal?> SizeArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  size .
+        ///     Sets the source reference on Chart Studio Cloud for <c>size</c>.
         /// </summary>
         [JsonPropertyName(@"sizesrc")]
         public string SizeSrc { get; set;} 

--- a/Plotly.Blazor/Traces/PieLib/TextFont.cs
+++ b/Plotly.Blazor/Traces/PieLib/TextFont.cs
@@ -34,7 +34,7 @@ namespace Plotly.Blazor.Traces.PieLib
         public IList<object> ColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  color .
+        ///     Sets the source reference on Chart Studio Cloud for <c>color</c>.
         /// </summary>
         [JsonPropertyName(@"colorsrc")]
         public string ColorSrc { get; set;} 
@@ -73,7 +73,7 @@ namespace Plotly.Blazor.Traces.PieLib
         public IList<string> FamilyArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  family .
+        ///     Sets the source reference on Chart Studio Cloud for <c>family</c>.
         /// </summary>
         [JsonPropertyName(@"familysrc")]
         public string FamilySrc { get; set;} 
@@ -92,7 +92,7 @@ namespace Plotly.Blazor.Traces.PieLib
         public IList<decimal?> SizeArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  size .
+        ///     Sets the source reference on Chart Studio Cloud for <c>size</c>.
         /// </summary>
         [JsonPropertyName(@"sizesrc")]
         public string SizeSrc { get; set;} 

--- a/Plotly.Blazor/Traces/PieLib/TitleLib/Font.cs
+++ b/Plotly.Blazor/Traces/PieLib/TitleLib/Font.cs
@@ -34,7 +34,7 @@ namespace Plotly.Blazor.Traces.PieLib.TitleLib
         public IList<object> ColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  color .
+        ///     Sets the source reference on Chart Studio Cloud for <c>color</c>.
         /// </summary>
         [JsonPropertyName(@"colorsrc")]
         public string ColorSrc { get; set;} 
@@ -73,7 +73,7 @@ namespace Plotly.Blazor.Traces.PieLib.TitleLib
         public IList<string> FamilyArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  family .
+        ///     Sets the source reference on Chart Studio Cloud for <c>family</c>.
         /// </summary>
         [JsonPropertyName(@"familysrc")]
         public string FamilySrc { get; set;} 
@@ -92,7 +92,7 @@ namespace Plotly.Blazor.Traces.PieLib.TitleLib
         public IList<decimal?> SizeArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  size .
+        ///     Sets the source reference on Chart Studio Cloud for <c>size</c>.
         /// </summary>
         [JsonPropertyName(@"sizesrc")]
         public string SizeSrc { get; set;} 

--- a/Plotly.Blazor/Traces/PointCloud.cs
+++ b/Plotly.Blazor/Traces/PointCloud.cs
@@ -34,7 +34,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> CustomData { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  customdata .
+        ///     Sets the source reference on Chart Studio Cloud for <c>customdata</c>.
         /// </summary>
         [JsonPropertyName(@"customdatasrc")]
         public string CustomDataSrc { get; set;} 
@@ -57,7 +57,7 @@ namespace Plotly.Blazor.Traces
         public IList<Plotly.Blazor.Traces.PointCloudLib.HoverInfoFlag?> HoverInfoArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  hoverinfo .
+        ///     Sets the source reference on Chart Studio Cloud for <c>hoverinfo</c>.
         /// </summary>
         [JsonPropertyName(@"hoverinfosrc")]
         public string HoverInfoSrc { get; set;} 
@@ -77,7 +77,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> Ids { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  ids .
+        ///     Sets the source reference on Chart Studio Cloud for <c>ids</c>.
         /// </summary>
         [JsonPropertyName(@"idssrc")]
         public string IdsSrc { get; set;} 
@@ -94,7 +94,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> Indices { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  indices .
+        ///     Sets the source reference on Chart Studio Cloud for <c>indices</c>.
         /// </summary>
         [JsonPropertyName(@"indicessrc")]
         public string IndicesSrc { get; set;} 
@@ -158,7 +158,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> MetaArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  meta .
+        ///     Sets the source reference on Chart Studio Cloud for <c>meta</c>.
         /// </summary>
         [JsonPropertyName(@"metasrc")]
         public string MetaSrc { get; set;} 
@@ -210,7 +210,7 @@ namespace Plotly.Blazor.Traces
         public IList<string> TextArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  text .
+        ///     Sets the source reference on Chart Studio Cloud for <c>text</c>.
         /// </summary>
         [JsonPropertyName(@"textsrc")]
         public string TextSrc { get; set;} 
@@ -270,13 +270,13 @@ namespace Plotly.Blazor.Traces
         public IList<object> XBounds { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  xbounds .
+        ///     Sets the source reference on Chart Studio Cloud for <c>xbounds</c>.
         /// </summary>
         [JsonPropertyName(@"xboundssrc")]
         public string XBoundsSrc { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  x .
+        ///     Sets the source reference on Chart Studio Cloud for <c>x</c>.
         /// </summary>
         [JsonPropertyName(@"xsrc")]
         public string XSrc { get; set;} 
@@ -290,7 +290,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> XY { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  xy .
+        ///     Sets the source reference on Chart Studio Cloud for <c>xy</c>.
         /// </summary>
         [JsonPropertyName(@"xysrc")]
         public string XYSrc { get; set;} 
@@ -318,13 +318,13 @@ namespace Plotly.Blazor.Traces
         public IList<object> YBounds { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  ybounds .
+        ///     Sets the source reference on Chart Studio Cloud for <c>ybounds</c>.
         /// </summary>
         [JsonPropertyName(@"yboundssrc")]
         public string YBoundsSrc { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  y .
+        ///     Sets the source reference on Chart Studio Cloud for <c>y</c>.
         /// </summary>
         [JsonPropertyName(@"ysrc")]
         public string YSrc { get; set;} 

--- a/Plotly.Blazor/Traces/PointCloudLib/HoverLabel.cs
+++ b/Plotly.Blazor/Traces/PointCloudLib/HoverLabel.cs
@@ -36,7 +36,7 @@ namespace Plotly.Blazor.Traces.PointCloudLib
         public IList<Plotly.Blazor.Traces.PointCloudLib.HoverLabelLib.AlignEnum?> AlignArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  align .
+        ///     Sets the source reference on Chart Studio Cloud for <c>align</c>.
         /// </summary>
         [JsonPropertyName(@"alignsrc")]
         public string AlignSrc { get; set;} 
@@ -55,7 +55,7 @@ namespace Plotly.Blazor.Traces.PointCloudLib
         public IList<object> BgColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  bgcolor .
+        ///     Sets the source reference on Chart Studio Cloud for <c>bgcolor</c>.
         /// </summary>
         [JsonPropertyName(@"bgcolorsrc")]
         public string BgColorSrc { get; set;} 
@@ -74,7 +74,7 @@ namespace Plotly.Blazor.Traces.PointCloudLib
         public IList<object> BorderColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  bordercolor .
+        ///     Sets the source reference on Chart Studio Cloud for <c>bordercolor</c>.
         /// </summary>
         [JsonPropertyName(@"bordercolorsrc")]
         public string BorderColorSrc { get; set;} 
@@ -107,7 +107,7 @@ namespace Plotly.Blazor.Traces.PointCloudLib
         public IList<int?> NameLengthArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  namelength .
+        ///     Sets the source reference on Chart Studio Cloud for <c>namelength</c>.
         /// </summary>
         [JsonPropertyName(@"namelengthsrc")]
         public string NameLengthSrc { get; set;} 

--- a/Plotly.Blazor/Traces/PointCloudLib/HoverLabelLib/Font.cs
+++ b/Plotly.Blazor/Traces/PointCloudLib/HoverLabelLib/Font.cs
@@ -34,7 +34,7 @@ namespace Plotly.Blazor.Traces.PointCloudLib.HoverLabelLib
         public IList<object> ColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  color .
+        ///     Sets the source reference on Chart Studio Cloud for <c>color</c>.
         /// </summary>
         [JsonPropertyName(@"colorsrc")]
         public string ColorSrc { get; set;} 
@@ -73,7 +73,7 @@ namespace Plotly.Blazor.Traces.PointCloudLib.HoverLabelLib
         public IList<string> FamilyArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  family .
+        ///     Sets the source reference on Chart Studio Cloud for <c>family</c>.
         /// </summary>
         [JsonPropertyName(@"familysrc")]
         public string FamilySrc { get; set;} 
@@ -92,7 +92,7 @@ namespace Plotly.Blazor.Traces.PointCloudLib.HoverLabelLib
         public IList<decimal?> SizeArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  size .
+        ///     Sets the source reference on Chart Studio Cloud for <c>size</c>.
         /// </summary>
         [JsonPropertyName(@"sizesrc")]
         public string SizeSrc { get; set;} 

--- a/Plotly.Blazor/Traces/Sankey.cs
+++ b/Plotly.Blazor/Traces/Sankey.cs
@@ -45,7 +45,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> CustomData { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  customdata .
+        ///     Sets the source reference on Chart Studio Cloud for <c>customdata</c>.
         /// </summary>
         [JsonPropertyName(@"customdatasrc")]
         public string CustomDataSrc { get; set;} 
@@ -81,7 +81,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> Ids { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  ids .
+        ///     Sets the source reference on Chart Studio Cloud for <c>ids</c>.
         /// </summary>
         [JsonPropertyName(@"idssrc")]
         public string IdsSrc { get; set;} 
@@ -138,7 +138,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> MetaArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  meta .
+        ///     Sets the source reference on Chart Studio Cloud for <c>meta</c>.
         /// </summary>
         [JsonPropertyName(@"metasrc")]
         public string MetaSrc { get; set;} 

--- a/Plotly.Blazor/Traces/SankeyLib/HoverLabel.cs
+++ b/Plotly.Blazor/Traces/SankeyLib/HoverLabel.cs
@@ -36,7 +36,7 @@ namespace Plotly.Blazor.Traces.SankeyLib
         public IList<Plotly.Blazor.Traces.SankeyLib.HoverLabelLib.AlignEnum?> AlignArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  align .
+        ///     Sets the source reference on Chart Studio Cloud for <c>align</c>.
         /// </summary>
         [JsonPropertyName(@"alignsrc")]
         public string AlignSrc { get; set;} 
@@ -55,7 +55,7 @@ namespace Plotly.Blazor.Traces.SankeyLib
         public IList<object> BgColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  bgcolor .
+        ///     Sets the source reference on Chart Studio Cloud for <c>bgcolor</c>.
         /// </summary>
         [JsonPropertyName(@"bgcolorsrc")]
         public string BgColorSrc { get; set;} 
@@ -74,7 +74,7 @@ namespace Plotly.Blazor.Traces.SankeyLib
         public IList<object> BorderColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  bordercolor .
+        ///     Sets the source reference on Chart Studio Cloud for <c>bordercolor</c>.
         /// </summary>
         [JsonPropertyName(@"bordercolorsrc")]
         public string BorderColorSrc { get; set;} 
@@ -107,7 +107,7 @@ namespace Plotly.Blazor.Traces.SankeyLib
         public IList<int?> NameLengthArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  namelength .
+        ///     Sets the source reference on Chart Studio Cloud for <c>namelength</c>.
         /// </summary>
         [JsonPropertyName(@"namelengthsrc")]
         public string NameLengthSrc { get; set;} 

--- a/Plotly.Blazor/Traces/SankeyLib/HoverLabelLib/Font.cs
+++ b/Plotly.Blazor/Traces/SankeyLib/HoverLabelLib/Font.cs
@@ -34,7 +34,7 @@ namespace Plotly.Blazor.Traces.SankeyLib.HoverLabelLib
         public IList<object> ColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  color .
+        ///     Sets the source reference on Chart Studio Cloud for <c>color</c>.
         /// </summary>
         [JsonPropertyName(@"colorsrc")]
         public string ColorSrc { get; set;} 
@@ -73,7 +73,7 @@ namespace Plotly.Blazor.Traces.SankeyLib.HoverLabelLib
         public IList<string> FamilyArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  family .
+        ///     Sets the source reference on Chart Studio Cloud for <c>family</c>.
         /// </summary>
         [JsonPropertyName(@"familysrc")]
         public string FamilySrc { get; set;} 
@@ -92,7 +92,7 @@ namespace Plotly.Blazor.Traces.SankeyLib.HoverLabelLib
         public IList<decimal?> SizeArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  size .
+        ///     Sets the source reference on Chart Studio Cloud for <c>size</c>.
         /// </summary>
         [JsonPropertyName(@"sizesrc")]
         public string SizeSrc { get; set;} 

--- a/Plotly.Blazor/Traces/SankeyLib/Link.cs
+++ b/Plotly.Blazor/Traces/SankeyLib/Link.cs
@@ -44,7 +44,7 @@ namespace Plotly.Blazor.Traces.SankeyLib
         public IList<Plotly.Blazor.Traces.SankeyLib.LinkLib.ConcentrationScales> ColorScales { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  color .
+        ///     Sets the source reference on Chart Studio Cloud for <c>color</c>.
         /// </summary>
         [JsonPropertyName(@"colorsrc")]
         public string ColorSrc { get; set;} 
@@ -56,7 +56,7 @@ namespace Plotly.Blazor.Traces.SankeyLib
         public IList<object> CustomData { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  customdata .
+        ///     Sets the source reference on Chart Studio Cloud for <c>customdata</c>.
         /// </summary>
         [JsonPropertyName(@"customdatasrc")]
         public string CustomDataSrc { get; set;} 
@@ -125,7 +125,7 @@ namespace Plotly.Blazor.Traces.SankeyLib
         public IList<string> HoverTemplateArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  hovertemplate .
+        ///     Sets the source reference on Chart Studio Cloud for <c>hovertemplate</c>.
         /// </summary>
         [JsonPropertyName(@"hovertemplatesrc")]
         public string HoverTemplateSrc { get; set;} 
@@ -137,7 +137,7 @@ namespace Plotly.Blazor.Traces.SankeyLib
         public IList<object> Label { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  label .
+        ///     Sets the source reference on Chart Studio Cloud for <c>label</c>.
         /// </summary>
         [JsonPropertyName(@"labelsrc")]
         public string LabelSrc { get; set;} 
@@ -156,7 +156,7 @@ namespace Plotly.Blazor.Traces.SankeyLib
         public IList<object> Source { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  source .
+        ///     Sets the source reference on Chart Studio Cloud for <c>source</c>.
         /// </summary>
         [JsonPropertyName(@"sourcesrc")]
         public string SourceSrc { get; set;} 
@@ -169,7 +169,7 @@ namespace Plotly.Blazor.Traces.SankeyLib
         public IList<object> Target { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  target .
+        ///     Sets the source reference on Chart Studio Cloud for <c>target</c>.
         /// </summary>
         [JsonPropertyName(@"targetsrc")]
         public string TargetSrc { get; set;} 
@@ -181,7 +181,7 @@ namespace Plotly.Blazor.Traces.SankeyLib
         public IList<object> Value { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  value .
+        ///     Sets the source reference on Chart Studio Cloud for <c>value</c>.
         /// </summary>
         [JsonPropertyName(@"valuesrc")]
         public string ValueSrc { get; set;} 

--- a/Plotly.Blazor/Traces/SankeyLib/LinkLib/HoverLabel.cs
+++ b/Plotly.Blazor/Traces/SankeyLib/LinkLib/HoverLabel.cs
@@ -36,7 +36,7 @@ namespace Plotly.Blazor.Traces.SankeyLib.LinkLib
         public IList<Plotly.Blazor.Traces.SankeyLib.LinkLib.HoverLabelLib.AlignEnum?> AlignArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  align .
+        ///     Sets the source reference on Chart Studio Cloud for <c>align</c>.
         /// </summary>
         [JsonPropertyName(@"alignsrc")]
         public string AlignSrc { get; set;} 
@@ -55,7 +55,7 @@ namespace Plotly.Blazor.Traces.SankeyLib.LinkLib
         public IList<object> BgColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  bgcolor .
+        ///     Sets the source reference on Chart Studio Cloud for <c>bgcolor</c>.
         /// </summary>
         [JsonPropertyName(@"bgcolorsrc")]
         public string BgColorSrc { get; set;} 
@@ -74,7 +74,7 @@ namespace Plotly.Blazor.Traces.SankeyLib.LinkLib
         public IList<object> BorderColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  bordercolor .
+        ///     Sets the source reference on Chart Studio Cloud for <c>bordercolor</c>.
         /// </summary>
         [JsonPropertyName(@"bordercolorsrc")]
         public string BorderColorSrc { get; set;} 
@@ -107,7 +107,7 @@ namespace Plotly.Blazor.Traces.SankeyLib.LinkLib
         public IList<int?> NameLengthArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  namelength .
+        ///     Sets the source reference on Chart Studio Cloud for <c>namelength</c>.
         /// </summary>
         [JsonPropertyName(@"namelengthsrc")]
         public string NameLengthSrc { get; set;} 

--- a/Plotly.Blazor/Traces/SankeyLib/LinkLib/HoverLabelLib/Font.cs
+++ b/Plotly.Blazor/Traces/SankeyLib/LinkLib/HoverLabelLib/Font.cs
@@ -34,7 +34,7 @@ namespace Plotly.Blazor.Traces.SankeyLib.LinkLib.HoverLabelLib
         public IList<object> ColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  color .
+        ///     Sets the source reference on Chart Studio Cloud for <c>color</c>.
         /// </summary>
         [JsonPropertyName(@"colorsrc")]
         public string ColorSrc { get; set;} 
@@ -73,7 +73,7 @@ namespace Plotly.Blazor.Traces.SankeyLib.LinkLib.HoverLabelLib
         public IList<string> FamilyArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  family .
+        ///     Sets the source reference on Chart Studio Cloud for <c>family</c>.
         /// </summary>
         [JsonPropertyName(@"familysrc")]
         public string FamilySrc { get; set;} 
@@ -92,7 +92,7 @@ namespace Plotly.Blazor.Traces.SankeyLib.LinkLib.HoverLabelLib
         public IList<decimal?> SizeArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  size .
+        ///     Sets the source reference on Chart Studio Cloud for <c>size</c>.
         /// </summary>
         [JsonPropertyName(@"sizesrc")]
         public string SizeSrc { get; set;} 

--- a/Plotly.Blazor/Traces/SankeyLib/LinkLib/Line.cs
+++ b/Plotly.Blazor/Traces/SankeyLib/LinkLib/Line.cs
@@ -34,7 +34,7 @@ namespace Plotly.Blazor.Traces.SankeyLib.LinkLib
         public IList<object> ColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  color .
+        ///     Sets the source reference on Chart Studio Cloud for <c>color</c>.
         /// </summary>
         [JsonPropertyName(@"colorsrc")]
         public string ColorSrc { get; set;} 
@@ -53,7 +53,7 @@ namespace Plotly.Blazor.Traces.SankeyLib.LinkLib
         public IList<decimal?> WidthArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  width .
+        ///     Sets the source reference on Chart Studio Cloud for <c>width</c>.
         /// </summary>
         [JsonPropertyName(@"widthsrc")]
         public string WidthSrc { get; set;} 

--- a/Plotly.Blazor/Traces/SankeyLib/Node.cs
+++ b/Plotly.Blazor/Traces/SankeyLib/Node.cs
@@ -42,7 +42,7 @@ namespace Plotly.Blazor.Traces.SankeyLib
         public IList<object> ColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  color .
+        ///     Sets the source reference on Chart Studio Cloud for <c>color</c>.
         /// </summary>
         [JsonPropertyName(@"colorsrc")]
         public string ColorSrc { get; set;} 
@@ -54,7 +54,7 @@ namespace Plotly.Blazor.Traces.SankeyLib
         public IList<object> CustomData { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  customdata .
+        ///     Sets the source reference on Chart Studio Cloud for <c>customdata</c>.
         /// </summary>
         [JsonPropertyName(@"customdatasrc")]
         public string CustomDataSrc { get; set;} 
@@ -130,7 +130,7 @@ namespace Plotly.Blazor.Traces.SankeyLib
         public IList<string> HoverTemplateArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  hovertemplate .
+        ///     Sets the source reference on Chart Studio Cloud for <c>hovertemplate</c>.
         /// </summary>
         [JsonPropertyName(@"hovertemplatesrc")]
         public string HoverTemplateSrc { get; set;} 
@@ -142,7 +142,7 @@ namespace Plotly.Blazor.Traces.SankeyLib
         public IList<object> Label { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  label .
+        ///     Sets the source reference on Chart Studio Cloud for <c>label</c>.
         /// </summary>
         [JsonPropertyName(@"labelsrc")]
         public string LabelSrc { get; set;} 
@@ -172,7 +172,7 @@ namespace Plotly.Blazor.Traces.SankeyLib
         public IList<object> X { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  x .
+        ///     Sets the source reference on Chart Studio Cloud for <c>x</c>.
         /// </summary>
         [JsonPropertyName(@"xsrc")]
         public string XSrc { get; set;} 
@@ -184,7 +184,7 @@ namespace Plotly.Blazor.Traces.SankeyLib
         public IList<object> Y { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  y .
+        ///     Sets the source reference on Chart Studio Cloud for <c>y</c>.
         /// </summary>
         [JsonPropertyName(@"ysrc")]
         public string YSrc { get; set;} 

--- a/Plotly.Blazor/Traces/SankeyLib/NodeLib/HoverLabel.cs
+++ b/Plotly.Blazor/Traces/SankeyLib/NodeLib/HoverLabel.cs
@@ -36,7 +36,7 @@ namespace Plotly.Blazor.Traces.SankeyLib.NodeLib
         public IList<Plotly.Blazor.Traces.SankeyLib.NodeLib.HoverLabelLib.AlignEnum?> AlignArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  align .
+        ///     Sets the source reference on Chart Studio Cloud for <c>align</c>.
         /// </summary>
         [JsonPropertyName(@"alignsrc")]
         public string AlignSrc { get; set;} 
@@ -55,7 +55,7 @@ namespace Plotly.Blazor.Traces.SankeyLib.NodeLib
         public IList<object> BgColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  bgcolor .
+        ///     Sets the source reference on Chart Studio Cloud for <c>bgcolor</c>.
         /// </summary>
         [JsonPropertyName(@"bgcolorsrc")]
         public string BgColorSrc { get; set;} 
@@ -74,7 +74,7 @@ namespace Plotly.Blazor.Traces.SankeyLib.NodeLib
         public IList<object> BorderColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  bordercolor .
+        ///     Sets the source reference on Chart Studio Cloud for <c>bordercolor</c>.
         /// </summary>
         [JsonPropertyName(@"bordercolorsrc")]
         public string BorderColorSrc { get; set;} 
@@ -107,7 +107,7 @@ namespace Plotly.Blazor.Traces.SankeyLib.NodeLib
         public IList<int?> NameLengthArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  namelength .
+        ///     Sets the source reference on Chart Studio Cloud for <c>namelength</c>.
         /// </summary>
         [JsonPropertyName(@"namelengthsrc")]
         public string NameLengthSrc { get; set;} 

--- a/Plotly.Blazor/Traces/SankeyLib/NodeLib/HoverLabelLib/Font.cs
+++ b/Plotly.Blazor/Traces/SankeyLib/NodeLib/HoverLabelLib/Font.cs
@@ -34,7 +34,7 @@ namespace Plotly.Blazor.Traces.SankeyLib.NodeLib.HoverLabelLib
         public IList<object> ColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  color .
+        ///     Sets the source reference on Chart Studio Cloud for <c>color</c>.
         /// </summary>
         [JsonPropertyName(@"colorsrc")]
         public string ColorSrc { get; set;} 
@@ -73,7 +73,7 @@ namespace Plotly.Blazor.Traces.SankeyLib.NodeLib.HoverLabelLib
         public IList<string> FamilyArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  family .
+        ///     Sets the source reference on Chart Studio Cloud for <c>family</c>.
         /// </summary>
         [JsonPropertyName(@"familysrc")]
         public string FamilySrc { get; set;} 
@@ -92,7 +92,7 @@ namespace Plotly.Blazor.Traces.SankeyLib.NodeLib.HoverLabelLib
         public IList<decimal?> SizeArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  size .
+        ///     Sets the source reference on Chart Studio Cloud for <c>size</c>.
         /// </summary>
         [JsonPropertyName(@"sizesrc")]
         public string SizeSrc { get; set;} 

--- a/Plotly.Blazor/Traces/SankeyLib/NodeLib/Line.cs
+++ b/Plotly.Blazor/Traces/SankeyLib/NodeLib/Line.cs
@@ -34,7 +34,7 @@ namespace Plotly.Blazor.Traces.SankeyLib.NodeLib
         public IList<object> ColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  color .
+        ///     Sets the source reference on Chart Studio Cloud for <c>color</c>.
         /// </summary>
         [JsonPropertyName(@"colorsrc")]
         public string ColorSrc { get; set;} 
@@ -53,7 +53,7 @@ namespace Plotly.Blazor.Traces.SankeyLib.NodeLib
         public IList<decimal?> WidthArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  width .
+        ///     Sets the source reference on Chart Studio Cloud for <c>width</c>.
         /// </summary>
         [JsonPropertyName(@"widthsrc")]
         public string WidthSrc { get; set;} 

--- a/Plotly.Blazor/Traces/Scatter.cs
+++ b/Plotly.Blazor/Traces/Scatter.cs
@@ -49,7 +49,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> CustomData { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  customdata .
+        ///     Sets the source reference on Chart Studio Cloud for <c>customdata</c>.
         /// </summary>
         [JsonPropertyName(@"customdatasrc")]
         public string CustomDataSrc { get; set;} 
@@ -138,7 +138,7 @@ namespace Plotly.Blazor.Traces
         public IList<Plotly.Blazor.Traces.ScatterLib.HoverInfoFlag?> HoverInfoArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  hoverinfo .
+        ///     Sets the source reference on Chart Studio Cloud for <c>hoverinfo</c>.
         /// </summary>
         [JsonPropertyName(@"hoverinfosrc")]
         public string HoverInfoSrc { get; set;} 
@@ -208,7 +208,7 @@ namespace Plotly.Blazor.Traces
         public IList<string> HoverTemplateArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  hovertemplate .
+        ///     Sets the source reference on Chart Studio Cloud for <c>hovertemplate</c>.
         /// </summary>
         [JsonPropertyName(@"hovertemplatesrc")]
         public string HoverTemplateSrc { get; set;} 
@@ -233,7 +233,7 @@ namespace Plotly.Blazor.Traces
         public IList<string> HoverTextArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  hovertext .
+        ///     Sets the source reference on Chart Studio Cloud for <c>hovertext</c>.
         /// </summary>
         [JsonPropertyName(@"hovertextsrc")]
         public string HoverTextSrc { get; set;} 
@@ -247,7 +247,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> Ids { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  ids .
+        ///     Sets the source reference on Chart Studio Cloud for <c>ids</c>.
         /// </summary>
         [JsonPropertyName(@"idssrc")]
         public string IdsSrc { get; set;} 
@@ -317,7 +317,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> MetaArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  meta .
+        ///     Sets the source reference on Chart Studio Cloud for <c>meta</c>.
         /// </summary>
         [JsonPropertyName(@"metasrc")]
         public string MetaSrc { get; set;} 
@@ -453,13 +453,13 @@ namespace Plotly.Blazor.Traces
         public IList<Plotly.Blazor.Traces.ScatterLib.TextPositionEnum?> TextPositionArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  textposition .
+        ///     Sets the source reference on Chart Studio Cloud for <c>textposition</c>.
         /// </summary>
         [JsonPropertyName(@"textpositionsrc")]
         public string TextPositionSrc { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  text .
+        ///     Sets the source reference on Chart Studio Cloud for <c>text</c>.
         /// </summary>
         [JsonPropertyName(@"textsrc")]
         public string TextSrc { get; set;} 
@@ -496,7 +496,7 @@ namespace Plotly.Blazor.Traces
         public IList<string> TextTemplateArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  texttemplate .
+        ///     Sets the source reference on Chart Studio Cloud for <c>texttemplate</c>.
         /// </summary>
         [JsonPropertyName(@"texttemplatesrc")]
         public string TextTemplateSrc { get; set;} 
@@ -611,7 +611,7 @@ namespace Plotly.Blazor.Traces
         public Plotly.Blazor.Traces.ScatterLib.XPeriodAlignmentEnum? XPeriodAlignment { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  x .
+        ///     Sets the source reference on Chart Studio Cloud for <c>x</c>.
         /// </summary>
         [JsonPropertyName(@"xsrc")]
         public string XSrc { get; set;} 
@@ -682,7 +682,7 @@ namespace Plotly.Blazor.Traces
         public Plotly.Blazor.Traces.ScatterLib.YPeriodAlignmentEnum? YPeriodAlignment { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  y .
+        ///     Sets the source reference on Chart Studio Cloud for <c>y</c>.
         /// </summary>
         [JsonPropertyName(@"ysrc")]
         public string YSrc { get; set;} 

--- a/Plotly.Blazor/Traces/Scatter3D.cs
+++ b/Plotly.Blazor/Traces/Scatter3D.cs
@@ -41,7 +41,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> CustomData { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  customdata .
+        ///     Sets the source reference on Chart Studio Cloud for <c>customdata</c>.
         /// </summary>
         [JsonPropertyName(@"customdatasrc")]
         public string CustomDataSrc { get; set;} 
@@ -82,7 +82,7 @@ namespace Plotly.Blazor.Traces
         public IList<Plotly.Blazor.Traces.Scatter3DLib.HoverInfoFlag?> HoverInfoArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  hoverinfo .
+        ///     Sets the source reference on Chart Studio Cloud for <c>hoverinfo</c>.
         /// </summary>
         [JsonPropertyName(@"hoverinfosrc")]
         public string HoverInfoSrc { get; set;} 
@@ -143,7 +143,7 @@ namespace Plotly.Blazor.Traces
         public IList<string> HoverTemplateArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  hovertemplate .
+        ///     Sets the source reference on Chart Studio Cloud for <c>hovertemplate</c>.
         /// </summary>
         [JsonPropertyName(@"hovertemplatesrc")]
         public string HoverTemplateSrc { get; set;} 
@@ -168,7 +168,7 @@ namespace Plotly.Blazor.Traces
         public IList<string> HoverTextArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  hovertext .
+        ///     Sets the source reference on Chart Studio Cloud for <c>hovertext</c>.
         /// </summary>
         [JsonPropertyName(@"hovertextsrc")]
         public string HoverTextSrc { get; set;} 
@@ -182,7 +182,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> Ids { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  ids .
+        ///     Sets the source reference on Chart Studio Cloud for <c>ids</c>.
         /// </summary>
         [JsonPropertyName(@"idssrc")]
         public string IdsSrc { get; set;} 
@@ -252,7 +252,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> MetaArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  meta .
+        ///     Sets the source reference on Chart Studio Cloud for <c>meta</c>.
         /// </summary>
         [JsonPropertyName(@"metasrc")]
         public string MetaSrc { get; set;} 
@@ -364,13 +364,13 @@ namespace Plotly.Blazor.Traces
         public IList<Plotly.Blazor.Traces.Scatter3DLib.TextPositionEnum?> TextPositionArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  textposition .
+        ///     Sets the source reference on Chart Studio Cloud for <c>textposition</c>.
         /// </summary>
         [JsonPropertyName(@"textpositionsrc")]
         public string TextPositionSrc { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  text .
+        ///     Sets the source reference on Chart Studio Cloud for <c>text</c>.
         /// </summary>
         [JsonPropertyName(@"textsrc")]
         public string TextSrc { get; set;} 
@@ -407,7 +407,7 @@ namespace Plotly.Blazor.Traces
         public IList<string> TextTemplateArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  texttemplate .
+        ///     Sets the source reference on Chart Studio Cloud for <c>texttemplate</c>.
         /// </summary>
         [JsonPropertyName(@"texttemplatesrc")]
         public string TextTemplateSrc { get; set;} 
@@ -476,7 +476,7 @@ namespace Plotly.Blazor.Traces
         public string XHoverFormat { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  x .
+        ///     Sets the source reference on Chart Studio Cloud for <c>x</c>.
         /// </summary>
         [JsonPropertyName(@"xsrc")]
         public string XSrc { get; set;} 
@@ -507,7 +507,7 @@ namespace Plotly.Blazor.Traces
         public string YHoverFormat { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  y .
+        ///     Sets the source reference on Chart Studio Cloud for <c>y</c>.
         /// </summary>
         [JsonPropertyName(@"ysrc")]
         public string YSrc { get; set;} 
@@ -538,7 +538,7 @@ namespace Plotly.Blazor.Traces
         public string ZHoverFormat { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  z .
+        ///     Sets the source reference on Chart Studio Cloud for <c>z</c>.
         /// </summary>
         [JsonPropertyName(@"zsrc")]
         public string ZSrc { get; set;} 

--- a/Plotly.Blazor/Traces/Scatter3DLib/ErrorX.cs
+++ b/Plotly.Blazor/Traces/Scatter3DLib/ErrorX.cs
@@ -35,13 +35,13 @@ namespace Plotly.Blazor.Traces.Scatter3DLib
         public IList<object> ArrayMinus { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  arrayminus .
+        ///     Sets the source reference on Chart Studio Cloud for <c>arrayminus</c>.
         /// </summary>
         [JsonPropertyName(@"arrayminussrc")]
         public string ArrayMinusSrc { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  array .
+        ///     Sets the source reference on Chart Studio Cloud for <c>array</c>.
         /// </summary>
         [JsonPropertyName(@"arraysrc")]
         public string ArraySrc { get; set;} 

--- a/Plotly.Blazor/Traces/Scatter3DLib/ErrorY.cs
+++ b/Plotly.Blazor/Traces/Scatter3DLib/ErrorY.cs
@@ -35,13 +35,13 @@ namespace Plotly.Blazor.Traces.Scatter3DLib
         public IList<object> ArrayMinus { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  arrayminus .
+        ///     Sets the source reference on Chart Studio Cloud for <c>arrayminus</c>.
         /// </summary>
         [JsonPropertyName(@"arrayminussrc")]
         public string ArrayMinusSrc { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  array .
+        ///     Sets the source reference on Chart Studio Cloud for <c>array</c>.
         /// </summary>
         [JsonPropertyName(@"arraysrc")]
         public string ArraySrc { get; set;} 

--- a/Plotly.Blazor/Traces/Scatter3DLib/ErrorZ.cs
+++ b/Plotly.Blazor/Traces/Scatter3DLib/ErrorZ.cs
@@ -35,13 +35,13 @@ namespace Plotly.Blazor.Traces.Scatter3DLib
         public IList<object> ArrayMinus { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  arrayminus .
+        ///     Sets the source reference on Chart Studio Cloud for <c>arrayminus</c>.
         /// </summary>
         [JsonPropertyName(@"arrayminussrc")]
         public string ArrayMinusSrc { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  array .
+        ///     Sets the source reference on Chart Studio Cloud for <c>array</c>.
         /// </summary>
         [JsonPropertyName(@"arraysrc")]
         public string ArraySrc { get; set;} 

--- a/Plotly.Blazor/Traces/Scatter3DLib/HoverLabel.cs
+++ b/Plotly.Blazor/Traces/Scatter3DLib/HoverLabel.cs
@@ -36,7 +36,7 @@ namespace Plotly.Blazor.Traces.Scatter3DLib
         public IList<Plotly.Blazor.Traces.Scatter3DLib.HoverLabelLib.AlignEnum?> AlignArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  align .
+        ///     Sets the source reference on Chart Studio Cloud for <c>align</c>.
         /// </summary>
         [JsonPropertyName(@"alignsrc")]
         public string AlignSrc { get; set;} 
@@ -55,7 +55,7 @@ namespace Plotly.Blazor.Traces.Scatter3DLib
         public IList<object> BgColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  bgcolor .
+        ///     Sets the source reference on Chart Studio Cloud for <c>bgcolor</c>.
         /// </summary>
         [JsonPropertyName(@"bgcolorsrc")]
         public string BgColorSrc { get; set;} 
@@ -74,7 +74,7 @@ namespace Plotly.Blazor.Traces.Scatter3DLib
         public IList<object> BorderColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  bordercolor .
+        ///     Sets the source reference on Chart Studio Cloud for <c>bordercolor</c>.
         /// </summary>
         [JsonPropertyName(@"bordercolorsrc")]
         public string BorderColorSrc { get; set;} 
@@ -107,7 +107,7 @@ namespace Plotly.Blazor.Traces.Scatter3DLib
         public IList<int?> NameLengthArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  namelength .
+        ///     Sets the source reference on Chart Studio Cloud for <c>namelength</c>.
         /// </summary>
         [JsonPropertyName(@"namelengthsrc")]
         public string NameLengthSrc { get; set;} 

--- a/Plotly.Blazor/Traces/Scatter3DLib/HoverLabelLib/Font.cs
+++ b/Plotly.Blazor/Traces/Scatter3DLib/HoverLabelLib/Font.cs
@@ -34,7 +34,7 @@ namespace Plotly.Blazor.Traces.Scatter3DLib.HoverLabelLib
         public IList<object> ColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  color .
+        ///     Sets the source reference on Chart Studio Cloud for <c>color</c>.
         /// </summary>
         [JsonPropertyName(@"colorsrc")]
         public string ColorSrc { get; set;} 
@@ -73,7 +73,7 @@ namespace Plotly.Blazor.Traces.Scatter3DLib.HoverLabelLib
         public IList<string> FamilyArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  family .
+        ///     Sets the source reference on Chart Studio Cloud for <c>family</c>.
         /// </summary>
         [JsonPropertyName(@"familysrc")]
         public string FamilySrc { get; set;} 
@@ -92,7 +92,7 @@ namespace Plotly.Blazor.Traces.Scatter3DLib.HoverLabelLib
         public IList<decimal?> SizeArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  size .
+        ///     Sets the source reference on Chart Studio Cloud for <c>size</c>.
         /// </summary>
         [JsonPropertyName(@"sizesrc")]
         public string SizeSrc { get; set;} 

--- a/Plotly.Blazor/Traces/Scatter3DLib/Line.cs
+++ b/Plotly.Blazor/Traces/Scatter3DLib/Line.cs
@@ -113,7 +113,7 @@ namespace Plotly.Blazor.Traces.Scatter3DLib
         public object ColorScale { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  color .
+        ///     Sets the source reference on Chart Studio Cloud for <c>color</c>.
         /// </summary>
         [JsonPropertyName(@"colorsrc")]
         public string ColorSrc { get; set;} 

--- a/Plotly.Blazor/Traces/Scatter3DLib/Marker.cs
+++ b/Plotly.Blazor/Traces/Scatter3DLib/Marker.cs
@@ -114,7 +114,7 @@ namespace Plotly.Blazor.Traces.Scatter3DLib
         public object ColorScale { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  color .
+        ///     Sets the source reference on Chart Studio Cloud for <c>color</c>.
         /// </summary>
         [JsonPropertyName(@"colorsrc")]
         public string ColorSrc { get; set;} 
@@ -186,7 +186,7 @@ namespace Plotly.Blazor.Traces.Scatter3DLib
         public decimal? SizeRef { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  size .
+        ///     Sets the source reference on Chart Studio Cloud for <c>size</c>.
         /// </summary>
         [JsonPropertyName(@"sizesrc")]
         public string SizeSrc { get; set;} 
@@ -205,7 +205,7 @@ namespace Plotly.Blazor.Traces.Scatter3DLib
         public IList<Plotly.Blazor.Traces.Scatter3DLib.MarkerLib.SymbolEnum?> SymbolArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  symbol .
+        ///     Sets the source reference on Chart Studio Cloud for <c>symbol</c>.
         /// </summary>
         [JsonPropertyName(@"symbolsrc")]
         public string SymbolSrc { get; set;} 

--- a/Plotly.Blazor/Traces/Scatter3DLib/MarkerLib/Line.cs
+++ b/Plotly.Blazor/Traces/Scatter3DLib/MarkerLib/Line.cs
@@ -110,7 +110,7 @@ namespace Plotly.Blazor.Traces.Scatter3DLib.MarkerLib
         public object ColorScale { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  color .
+        ///     Sets the source reference on Chart Studio Cloud for <c>color</c>.
         /// </summary>
         [JsonPropertyName(@"colorsrc")]
         public string ColorSrc { get; set;} 

--- a/Plotly.Blazor/Traces/Scatter3DLib/TextFont.cs
+++ b/Plotly.Blazor/Traces/Scatter3DLib/TextFont.cs
@@ -34,7 +34,7 @@ namespace Plotly.Blazor.Traces.Scatter3DLib
         public IList<object> ColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  color .
+        ///     Sets the source reference on Chart Studio Cloud for <c>color</c>.
         /// </summary>
         [JsonPropertyName(@"colorsrc")]
         public string ColorSrc { get; set;} 
@@ -69,7 +69,7 @@ namespace Plotly.Blazor.Traces.Scatter3DLib
         public IList<decimal?> SizeArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  size .
+        ///     Sets the source reference on Chart Studio Cloud for <c>size</c>.
         /// </summary>
         [JsonPropertyName(@"sizesrc")]
         public string SizeSrc { get; set;} 

--- a/Plotly.Blazor/Traces/ScatterCarpet.cs
+++ b/Plotly.Blazor/Traces/ScatterCarpet.cs
@@ -32,7 +32,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> A { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  a .
+        ///     Sets the source reference on Chart Studio Cloud for <c>a</c>.
         /// </summary>
         [JsonPropertyName(@"asrc")]
         public string ASrc { get; set;} 
@@ -44,7 +44,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> B { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  b .
+        ///     Sets the source reference on Chart Studio Cloud for <c>b</c>.
         /// </summary>
         [JsonPropertyName(@"bsrc")]
         public string BSrc { get; set;} 
@@ -72,7 +72,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> CustomData { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  customdata .
+        ///     Sets the source reference on Chart Studio Cloud for <c>customdata</c>.
         /// </summary>
         [JsonPropertyName(@"customdatasrc")]
         public string CustomDataSrc { get; set;} 
@@ -114,7 +114,7 @@ namespace Plotly.Blazor.Traces
         public IList<Plotly.Blazor.Traces.ScatterCarpetLib.HoverInfoFlag?> HoverInfoArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  hoverinfo .
+        ///     Sets the source reference on Chart Studio Cloud for <c>hoverinfo</c>.
         /// </summary>
         [JsonPropertyName(@"hoverinfosrc")]
         public string HoverInfoSrc { get; set;} 
@@ -184,7 +184,7 @@ namespace Plotly.Blazor.Traces
         public IList<string> HoverTemplateArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  hovertemplate .
+        ///     Sets the source reference on Chart Studio Cloud for <c>hovertemplate</c>.
         /// </summary>
         [JsonPropertyName(@"hovertemplatesrc")]
         public string HoverTemplateSrc { get; set;} 
@@ -209,7 +209,7 @@ namespace Plotly.Blazor.Traces
         public IList<string> HoverTextArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  hovertext .
+        ///     Sets the source reference on Chart Studio Cloud for <c>hovertext</c>.
         /// </summary>
         [JsonPropertyName(@"hovertextsrc")]
         public string HoverTextSrc { get; set;} 
@@ -223,7 +223,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> Ids { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  ids .
+        ///     Sets the source reference on Chart Studio Cloud for <c>ids</c>.
         /// </summary>
         [JsonPropertyName(@"idssrc")]
         public string IdsSrc { get; set;} 
@@ -293,7 +293,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> MetaArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  meta .
+        ///     Sets the source reference on Chart Studio Cloud for <c>meta</c>.
         /// </summary>
         [JsonPropertyName(@"metasrc")]
         public string MetaSrc { get; set;} 
@@ -392,13 +392,13 @@ namespace Plotly.Blazor.Traces
         public IList<Plotly.Blazor.Traces.ScatterCarpetLib.TextPositionEnum?> TextPositionArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  textposition .
+        ///     Sets the source reference on Chart Studio Cloud for <c>textposition</c>.
         /// </summary>
         [JsonPropertyName(@"textpositionsrc")]
         public string TextPositionSrc { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  text .
+        ///     Sets the source reference on Chart Studio Cloud for <c>text</c>.
         /// </summary>
         [JsonPropertyName(@"textsrc")]
         public string TextSrc { get; set;} 
@@ -437,7 +437,7 @@ namespace Plotly.Blazor.Traces
         public IList<string> TextTemplateArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  texttemplate .
+        ///     Sets the source reference on Chart Studio Cloud for <c>texttemplate</c>.
         /// </summary>
         [JsonPropertyName(@"texttemplatesrc")]
         public string TextTemplateSrc { get; set;} 

--- a/Plotly.Blazor/Traces/ScatterCarpetLib/HoverLabel.cs
+++ b/Plotly.Blazor/Traces/ScatterCarpetLib/HoverLabel.cs
@@ -36,7 +36,7 @@ namespace Plotly.Blazor.Traces.ScatterCarpetLib
         public IList<Plotly.Blazor.Traces.ScatterCarpetLib.HoverLabelLib.AlignEnum?> AlignArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  align .
+        ///     Sets the source reference on Chart Studio Cloud for <c>align</c>.
         /// </summary>
         [JsonPropertyName(@"alignsrc")]
         public string AlignSrc { get; set;} 
@@ -55,7 +55,7 @@ namespace Plotly.Blazor.Traces.ScatterCarpetLib
         public IList<object> BgColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  bgcolor .
+        ///     Sets the source reference on Chart Studio Cloud for <c>bgcolor</c>.
         /// </summary>
         [JsonPropertyName(@"bgcolorsrc")]
         public string BgColorSrc { get; set;} 
@@ -74,7 +74,7 @@ namespace Plotly.Blazor.Traces.ScatterCarpetLib
         public IList<object> BorderColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  bordercolor .
+        ///     Sets the source reference on Chart Studio Cloud for <c>bordercolor</c>.
         /// </summary>
         [JsonPropertyName(@"bordercolorsrc")]
         public string BorderColorSrc { get; set;} 
@@ -107,7 +107,7 @@ namespace Plotly.Blazor.Traces.ScatterCarpetLib
         public IList<int?> NameLengthArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  namelength .
+        ///     Sets the source reference on Chart Studio Cloud for <c>namelength</c>.
         /// </summary>
         [JsonPropertyName(@"namelengthsrc")]
         public string NameLengthSrc { get; set;} 

--- a/Plotly.Blazor/Traces/ScatterCarpetLib/HoverLabelLib/Font.cs
+++ b/Plotly.Blazor/Traces/ScatterCarpetLib/HoverLabelLib/Font.cs
@@ -34,7 +34,7 @@ namespace Plotly.Blazor.Traces.ScatterCarpetLib.HoverLabelLib
         public IList<object> ColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  color .
+        ///     Sets the source reference on Chart Studio Cloud for <c>color</c>.
         /// </summary>
         [JsonPropertyName(@"colorsrc")]
         public string ColorSrc { get; set;} 
@@ -73,7 +73,7 @@ namespace Plotly.Blazor.Traces.ScatterCarpetLib.HoverLabelLib
         public IList<string> FamilyArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  family .
+        ///     Sets the source reference on Chart Studio Cloud for <c>family</c>.
         /// </summary>
         [JsonPropertyName(@"familysrc")]
         public string FamilySrc { get; set;} 
@@ -92,7 +92,7 @@ namespace Plotly.Blazor.Traces.ScatterCarpetLib.HoverLabelLib
         public IList<decimal?> SizeArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  size .
+        ///     Sets the source reference on Chart Studio Cloud for <c>size</c>.
         /// </summary>
         [JsonPropertyName(@"sizesrc")]
         public string SizeSrc { get; set;} 

--- a/Plotly.Blazor/Traces/ScatterCarpetLib/Marker.cs
+++ b/Plotly.Blazor/Traces/ScatterCarpetLib/Marker.cs
@@ -114,7 +114,7 @@ namespace Plotly.Blazor.Traces.ScatterCarpetLib
         public object ColorScale { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  color .
+        ///     Sets the source reference on Chart Studio Cloud for <c>color</c>.
         /// </summary>
         [JsonPropertyName(@"colorsrc")]
         public string ColorSrc { get; set;} 
@@ -152,7 +152,7 @@ namespace Plotly.Blazor.Traces.ScatterCarpetLib
         public IList<decimal?> OpacityArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  opacity .
+        ///     Sets the source reference on Chart Studio Cloud for <c>opacity</c>.
         /// </summary>
         [JsonPropertyName(@"opacitysrc")]
         public string OpacitySrc { get; set;} 
@@ -209,7 +209,7 @@ namespace Plotly.Blazor.Traces.ScatterCarpetLib
         public decimal? SizeRef { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  size .
+        ///     Sets the source reference on Chart Studio Cloud for <c>size</c>.
         /// </summary>
         [JsonPropertyName(@"sizesrc")]
         public string SizeSrc { get; set;} 
@@ -234,7 +234,7 @@ namespace Plotly.Blazor.Traces.ScatterCarpetLib
         public IList<Plotly.Blazor.Traces.ScatterCarpetLib.MarkerLib.SymbolEnum?> SymbolArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  symbol .
+        ///     Sets the source reference on Chart Studio Cloud for <c>symbol</c>.
         /// </summary>
         [JsonPropertyName(@"symbolsrc")]
         public string SymbolSrc { get; set;} 

--- a/Plotly.Blazor/Traces/ScatterCarpetLib/MarkerLib/Gradient.cs
+++ b/Plotly.Blazor/Traces/ScatterCarpetLib/MarkerLib/Gradient.cs
@@ -36,7 +36,7 @@ namespace Plotly.Blazor.Traces.ScatterCarpetLib.MarkerLib
         public IList<object> ColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  color .
+        ///     Sets the source reference on Chart Studio Cloud for <c>color</c>.
         /// </summary>
         [JsonPropertyName(@"colorsrc")]
         public string ColorSrc { get; set;} 
@@ -55,7 +55,7 @@ namespace Plotly.Blazor.Traces.ScatterCarpetLib.MarkerLib
         public IList<Plotly.Blazor.Traces.ScatterCarpetLib.MarkerLib.GradientLib.TypeEnum?> TypeArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  type .
+        ///     Sets the source reference on Chart Studio Cloud for <c>type</c>.
         /// </summary>
         [JsonPropertyName(@"typesrc")]
         public string TypeSrc { get; set;} 

--- a/Plotly.Blazor/Traces/ScatterCarpetLib/MarkerLib/Line.cs
+++ b/Plotly.Blazor/Traces/ScatterCarpetLib/MarkerLib/Line.cs
@@ -110,7 +110,7 @@ namespace Plotly.Blazor.Traces.ScatterCarpetLib.MarkerLib
         public object ColorScale { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  color .
+        ///     Sets the source reference on Chart Studio Cloud for <c>color</c>.
         /// </summary>
         [JsonPropertyName(@"colorsrc")]
         public string ColorSrc { get; set;} 
@@ -138,7 +138,7 @@ namespace Plotly.Blazor.Traces.ScatterCarpetLib.MarkerLib
         public IList<decimal?> WidthArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  width .
+        ///     Sets the source reference on Chart Studio Cloud for <c>width</c>.
         /// </summary>
         [JsonPropertyName(@"widthsrc")]
         public string WidthSrc { get; set;} 

--- a/Plotly.Blazor/Traces/ScatterCarpetLib/TextFont.cs
+++ b/Plotly.Blazor/Traces/ScatterCarpetLib/TextFont.cs
@@ -34,7 +34,7 @@ namespace Plotly.Blazor.Traces.ScatterCarpetLib
         public IList<object> ColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  color .
+        ///     Sets the source reference on Chart Studio Cloud for <c>color</c>.
         /// </summary>
         [JsonPropertyName(@"colorsrc")]
         public string ColorSrc { get; set;} 
@@ -73,7 +73,7 @@ namespace Plotly.Blazor.Traces.ScatterCarpetLib
         public IList<string> FamilyArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  family .
+        ///     Sets the source reference on Chart Studio Cloud for <c>family</c>.
         /// </summary>
         [JsonPropertyName(@"familysrc")]
         public string FamilySrc { get; set;} 
@@ -92,7 +92,7 @@ namespace Plotly.Blazor.Traces.ScatterCarpetLib
         public IList<decimal?> SizeArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  size .
+        ///     Sets the source reference on Chart Studio Cloud for <c>size</c>.
         /// </summary>
         [JsonPropertyName(@"sizesrc")]
         public string SizeSrc { get; set;} 

--- a/Plotly.Blazor/Traces/ScatterGeo.cs
+++ b/Plotly.Blazor/Traces/ScatterGeo.cs
@@ -41,7 +41,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> CustomData { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  customdata .
+        ///     Sets the source reference on Chart Studio Cloud for <c>customdata</c>.
         /// </summary>
         [JsonPropertyName(@"customdatasrc")]
         public string CustomDataSrc { get; set;} 
@@ -106,7 +106,7 @@ namespace Plotly.Blazor.Traces
         public IList<Plotly.Blazor.Traces.ScatterGeoLib.HoverInfoFlag?> HoverInfoArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  hoverinfo .
+        ///     Sets the source reference on Chart Studio Cloud for <c>hoverinfo</c>.
         /// </summary>
         [JsonPropertyName(@"hoverinfosrc")]
         public string HoverInfoSrc { get; set;} 
@@ -167,7 +167,7 @@ namespace Plotly.Blazor.Traces
         public IList<string> HoverTemplateArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  hovertemplate .
+        ///     Sets the source reference on Chart Studio Cloud for <c>hovertemplate</c>.
         /// </summary>
         [JsonPropertyName(@"hovertemplatesrc")]
         public string HoverTemplateSrc { get; set;} 
@@ -194,7 +194,7 @@ namespace Plotly.Blazor.Traces
         public IList<string> HoverTextArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  hovertext .
+        ///     Sets the source reference on Chart Studio Cloud for <c>hovertext</c>.
         /// </summary>
         [JsonPropertyName(@"hovertextsrc")]
         public string HoverTextSrc { get; set;} 
@@ -208,7 +208,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> Ids { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  ids .
+        ///     Sets the source reference on Chart Studio Cloud for <c>ids</c>.
         /// </summary>
         [JsonPropertyName(@"idssrc")]
         public string IdsSrc { get; set;} 
@@ -220,7 +220,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> Lat { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  lat .
+        ///     Sets the source reference on Chart Studio Cloud for <c>lat</c>.
         /// </summary>
         [JsonPropertyName(@"latsrc")]
         public string LatSrc { get; set;} 
@@ -272,7 +272,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> Locations { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  locations .
+        ///     Sets the source reference on Chart Studio Cloud for <c>locations</c>.
         /// </summary>
         [JsonPropertyName(@"locationssrc")]
         public string LocationsSrc { get; set;} 
@@ -284,7 +284,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> Lon { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  lon .
+        ///     Sets the source reference on Chart Studio Cloud for <c>lon</c>.
         /// </summary>
         [JsonPropertyName(@"lonsrc")]
         public string LonSrc { get; set;} 
@@ -325,7 +325,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> MetaArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  meta .
+        ///     Sets the source reference on Chart Studio Cloud for <c>meta</c>.
         /// </summary>
         [JsonPropertyName(@"metasrc")]
         public string MetaSrc { get; set;} 
@@ -426,13 +426,13 @@ namespace Plotly.Blazor.Traces
         public IList<Plotly.Blazor.Traces.ScatterGeoLib.TextPositionEnum?> TextPositionArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  textposition .
+        ///     Sets the source reference on Chart Studio Cloud for <c>textposition</c>.
         /// </summary>
         [JsonPropertyName(@"textpositionsrc")]
         public string TextPositionSrc { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  text .
+        ///     Sets the source reference on Chart Studio Cloud for <c>text</c>.
         /// </summary>
         [JsonPropertyName(@"textsrc")]
         public string TextSrc { get; set;} 
@@ -471,7 +471,7 @@ namespace Plotly.Blazor.Traces
         public IList<string> TextTemplateArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  texttemplate .
+        ///     Sets the source reference on Chart Studio Cloud for <c>texttemplate</c>.
         /// </summary>
         [JsonPropertyName(@"texttemplatesrc")]
         public string TextTemplateSrc { get; set;} 

--- a/Plotly.Blazor/Traces/ScatterGeoLib/HoverLabel.cs
+++ b/Plotly.Blazor/Traces/ScatterGeoLib/HoverLabel.cs
@@ -36,7 +36,7 @@ namespace Plotly.Blazor.Traces.ScatterGeoLib
         public IList<Plotly.Blazor.Traces.ScatterGeoLib.HoverLabelLib.AlignEnum?> AlignArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  align .
+        ///     Sets the source reference on Chart Studio Cloud for <c>align</c>.
         /// </summary>
         [JsonPropertyName(@"alignsrc")]
         public string AlignSrc { get; set;} 
@@ -55,7 +55,7 @@ namespace Plotly.Blazor.Traces.ScatterGeoLib
         public IList<object> BgColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  bgcolor .
+        ///     Sets the source reference on Chart Studio Cloud for <c>bgcolor</c>.
         /// </summary>
         [JsonPropertyName(@"bgcolorsrc")]
         public string BgColorSrc { get; set;} 
@@ -74,7 +74,7 @@ namespace Plotly.Blazor.Traces.ScatterGeoLib
         public IList<object> BorderColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  bordercolor .
+        ///     Sets the source reference on Chart Studio Cloud for <c>bordercolor</c>.
         /// </summary>
         [JsonPropertyName(@"bordercolorsrc")]
         public string BorderColorSrc { get; set;} 
@@ -107,7 +107,7 @@ namespace Plotly.Blazor.Traces.ScatterGeoLib
         public IList<int?> NameLengthArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  namelength .
+        ///     Sets the source reference on Chart Studio Cloud for <c>namelength</c>.
         /// </summary>
         [JsonPropertyName(@"namelengthsrc")]
         public string NameLengthSrc { get; set;} 

--- a/Plotly.Blazor/Traces/ScatterGeoLib/HoverLabelLib/Font.cs
+++ b/Plotly.Blazor/Traces/ScatterGeoLib/HoverLabelLib/Font.cs
@@ -34,7 +34,7 @@ namespace Plotly.Blazor.Traces.ScatterGeoLib.HoverLabelLib
         public IList<object> ColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  color .
+        ///     Sets the source reference on Chart Studio Cloud for <c>color</c>.
         /// </summary>
         [JsonPropertyName(@"colorsrc")]
         public string ColorSrc { get; set;} 
@@ -73,7 +73,7 @@ namespace Plotly.Blazor.Traces.ScatterGeoLib.HoverLabelLib
         public IList<string> FamilyArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  family .
+        ///     Sets the source reference on Chart Studio Cloud for <c>family</c>.
         /// </summary>
         [JsonPropertyName(@"familysrc")]
         public string FamilySrc { get; set;} 
@@ -92,7 +92,7 @@ namespace Plotly.Blazor.Traces.ScatterGeoLib.HoverLabelLib
         public IList<decimal?> SizeArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  size .
+        ///     Sets the source reference on Chart Studio Cloud for <c>size</c>.
         /// </summary>
         [JsonPropertyName(@"sizesrc")]
         public string SizeSrc { get; set;} 

--- a/Plotly.Blazor/Traces/ScatterGeoLib/Marker.cs
+++ b/Plotly.Blazor/Traces/ScatterGeoLib/Marker.cs
@@ -114,7 +114,7 @@ namespace Plotly.Blazor.Traces.ScatterGeoLib
         public object ColorScale { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  color .
+        ///     Sets the source reference on Chart Studio Cloud for <c>color</c>.
         /// </summary>
         [JsonPropertyName(@"colorsrc")]
         public string ColorSrc { get; set;} 
@@ -145,7 +145,7 @@ namespace Plotly.Blazor.Traces.ScatterGeoLib
         public IList<decimal?> OpacityArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  opacity .
+        ///     Sets the source reference on Chart Studio Cloud for <c>opacity</c>.
         /// </summary>
         [JsonPropertyName(@"opacitysrc")]
         public string OpacitySrc { get; set;} 
@@ -202,7 +202,7 @@ namespace Plotly.Blazor.Traces.ScatterGeoLib
         public decimal? SizeRef { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  size .
+        ///     Sets the source reference on Chart Studio Cloud for <c>size</c>.
         /// </summary>
         [JsonPropertyName(@"sizesrc")]
         public string SizeSrc { get; set;} 
@@ -227,7 +227,7 @@ namespace Plotly.Blazor.Traces.ScatterGeoLib
         public IList<Plotly.Blazor.Traces.ScatterGeoLib.MarkerLib.SymbolEnum?> SymbolArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  symbol .
+        ///     Sets the source reference on Chart Studio Cloud for <c>symbol</c>.
         /// </summary>
         [JsonPropertyName(@"symbolsrc")]
         public string SymbolSrc { get; set;} 

--- a/Plotly.Blazor/Traces/ScatterGeoLib/MarkerLib/Gradient.cs
+++ b/Plotly.Blazor/Traces/ScatterGeoLib/MarkerLib/Gradient.cs
@@ -36,7 +36,7 @@ namespace Plotly.Blazor.Traces.ScatterGeoLib.MarkerLib
         public IList<object> ColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  color .
+        ///     Sets the source reference on Chart Studio Cloud for <c>color</c>.
         /// </summary>
         [JsonPropertyName(@"colorsrc")]
         public string ColorSrc { get; set;} 
@@ -55,7 +55,7 @@ namespace Plotly.Blazor.Traces.ScatterGeoLib.MarkerLib
         public IList<Plotly.Blazor.Traces.ScatterGeoLib.MarkerLib.GradientLib.TypeEnum?> TypeArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  type .
+        ///     Sets the source reference on Chart Studio Cloud for <c>type</c>.
         /// </summary>
         [JsonPropertyName(@"typesrc")]
         public string TypeSrc { get; set;} 

--- a/Plotly.Blazor/Traces/ScatterGeoLib/MarkerLib/Line.cs
+++ b/Plotly.Blazor/Traces/ScatterGeoLib/MarkerLib/Line.cs
@@ -110,7 +110,7 @@ namespace Plotly.Blazor.Traces.ScatterGeoLib.MarkerLib
         public object ColorScale { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  color .
+        ///     Sets the source reference on Chart Studio Cloud for <c>color</c>.
         /// </summary>
         [JsonPropertyName(@"colorsrc")]
         public string ColorSrc { get; set;} 
@@ -138,7 +138,7 @@ namespace Plotly.Blazor.Traces.ScatterGeoLib.MarkerLib
         public IList<decimal?> WidthArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  width .
+        ///     Sets the source reference on Chart Studio Cloud for <c>width</c>.
         /// </summary>
         [JsonPropertyName(@"widthsrc")]
         public string WidthSrc { get; set;} 

--- a/Plotly.Blazor/Traces/ScatterGeoLib/TextFont.cs
+++ b/Plotly.Blazor/Traces/ScatterGeoLib/TextFont.cs
@@ -34,7 +34,7 @@ namespace Plotly.Blazor.Traces.ScatterGeoLib
         public IList<object> ColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  color .
+        ///     Sets the source reference on Chart Studio Cloud for <c>color</c>.
         /// </summary>
         [JsonPropertyName(@"colorsrc")]
         public string ColorSrc { get; set;} 
@@ -73,7 +73,7 @@ namespace Plotly.Blazor.Traces.ScatterGeoLib
         public IList<string> FamilyArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  family .
+        ///     Sets the source reference on Chart Studio Cloud for <c>family</c>.
         /// </summary>
         [JsonPropertyName(@"familysrc")]
         public string FamilySrc { get; set;} 
@@ -92,7 +92,7 @@ namespace Plotly.Blazor.Traces.ScatterGeoLib
         public IList<decimal?> SizeArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  size .
+        ///     Sets the source reference on Chart Studio Cloud for <c>size</c>.
         /// </summary>
         [JsonPropertyName(@"sizesrc")]
         public string SizeSrc { get; set;} 

--- a/Plotly.Blazor/Traces/ScatterGl.cs
+++ b/Plotly.Blazor/Traces/ScatterGl.cs
@@ -41,7 +41,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> CustomData { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  customdata .
+        ///     Sets the source reference on Chart Studio Cloud for <c>customdata</c>.
         /// </summary>
         [JsonPropertyName(@"customdatasrc")]
         public string CustomDataSrc { get; set;} 
@@ -117,7 +117,7 @@ namespace Plotly.Blazor.Traces
         public IList<Plotly.Blazor.Traces.ScatterGlLib.HoverInfoFlag?> HoverInfoArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  hoverinfo .
+        ///     Sets the source reference on Chart Studio Cloud for <c>hoverinfo</c>.
         /// </summary>
         [JsonPropertyName(@"hoverinfosrc")]
         public string HoverInfoSrc { get; set;} 
@@ -178,7 +178,7 @@ namespace Plotly.Blazor.Traces
         public IList<string> HoverTemplateArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  hovertemplate .
+        ///     Sets the source reference on Chart Studio Cloud for <c>hovertemplate</c>.
         /// </summary>
         [JsonPropertyName(@"hovertemplatesrc")]
         public string HoverTemplateSrc { get; set;} 
@@ -203,7 +203,7 @@ namespace Plotly.Blazor.Traces
         public IList<string> HoverTextArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  hovertext .
+        ///     Sets the source reference on Chart Studio Cloud for <c>hovertext</c>.
         /// </summary>
         [JsonPropertyName(@"hovertextsrc")]
         public string HoverTextSrc { get; set;} 
@@ -217,7 +217,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> Ids { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  ids .
+        ///     Sets the source reference on Chart Studio Cloud for <c>ids</c>.
         /// </summary>
         [JsonPropertyName(@"idssrc")]
         public string IdsSrc { get; set;} 
@@ -287,7 +287,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> MetaArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  meta .
+        ///     Sets the source reference on Chart Studio Cloud for <c>meta</c>.
         /// </summary>
         [JsonPropertyName(@"metasrc")]
         public string MetaSrc { get; set;} 
@@ -382,13 +382,13 @@ namespace Plotly.Blazor.Traces
         public IList<Plotly.Blazor.Traces.ScatterGlLib.TextPositionEnum?> TextPositionArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  textposition .
+        ///     Sets the source reference on Chart Studio Cloud for <c>textposition</c>.
         /// </summary>
         [JsonPropertyName(@"textpositionsrc")]
         public string TextPositionSrc { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  text .
+        ///     Sets the source reference on Chart Studio Cloud for <c>text</c>.
         /// </summary>
         [JsonPropertyName(@"textsrc")]
         public string TextSrc { get; set;} 
@@ -425,7 +425,7 @@ namespace Plotly.Blazor.Traces
         public IList<string> TextTemplateArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  texttemplate .
+        ///     Sets the source reference on Chart Studio Cloud for <c>texttemplate</c>.
         /// </summary>
         [JsonPropertyName(@"texttemplatesrc")]
         public string TextTemplateSrc { get; set;} 
@@ -540,7 +540,7 @@ namespace Plotly.Blazor.Traces
         public Plotly.Blazor.Traces.ScatterGlLib.XPeriodAlignmentEnum? XPeriodAlignment { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  x .
+        ///     Sets the source reference on Chart Studio Cloud for <c>x</c>.
         /// </summary>
         [JsonPropertyName(@"xsrc")]
         public string XSrc { get; set;} 
@@ -611,7 +611,7 @@ namespace Plotly.Blazor.Traces
         public Plotly.Blazor.Traces.ScatterGlLib.YPeriodAlignmentEnum? YPeriodAlignment { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  y .
+        ///     Sets the source reference on Chart Studio Cloud for <c>y</c>.
         /// </summary>
         [JsonPropertyName(@"ysrc")]
         public string YSrc { get; set;} 

--- a/Plotly.Blazor/Traces/ScatterGlLib/ErrorX.cs
+++ b/Plotly.Blazor/Traces/ScatterGlLib/ErrorX.cs
@@ -35,13 +35,13 @@ namespace Plotly.Blazor.Traces.ScatterGlLib
         public IList<object> ArrayMinus { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  arrayminus .
+        ///     Sets the source reference on Chart Studio Cloud for <c>arrayminus</c>.
         /// </summary>
         [JsonPropertyName(@"arrayminussrc")]
         public string ArrayMinusSrc { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  array .
+        ///     Sets the source reference on Chart Studio Cloud for <c>array</c>.
         /// </summary>
         [JsonPropertyName(@"arraysrc")]
         public string ArraySrc { get; set;} 

--- a/Plotly.Blazor/Traces/ScatterGlLib/ErrorY.cs
+++ b/Plotly.Blazor/Traces/ScatterGlLib/ErrorY.cs
@@ -35,13 +35,13 @@ namespace Plotly.Blazor.Traces.ScatterGlLib
         public IList<object> ArrayMinus { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  arrayminus .
+        ///     Sets the source reference on Chart Studio Cloud for <c>arrayminus</c>.
         /// </summary>
         [JsonPropertyName(@"arrayminussrc")]
         public string ArrayMinusSrc { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  array .
+        ///     Sets the source reference on Chart Studio Cloud for <c>array</c>.
         /// </summary>
         [JsonPropertyName(@"arraysrc")]
         public string ArraySrc { get; set;} 

--- a/Plotly.Blazor/Traces/ScatterGlLib/HoverLabel.cs
+++ b/Plotly.Blazor/Traces/ScatterGlLib/HoverLabel.cs
@@ -36,7 +36,7 @@ namespace Plotly.Blazor.Traces.ScatterGlLib
         public IList<Plotly.Blazor.Traces.ScatterGlLib.HoverLabelLib.AlignEnum?> AlignArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  align .
+        ///     Sets the source reference on Chart Studio Cloud for <c>align</c>.
         /// </summary>
         [JsonPropertyName(@"alignsrc")]
         public string AlignSrc { get; set;} 
@@ -55,7 +55,7 @@ namespace Plotly.Blazor.Traces.ScatterGlLib
         public IList<object> BgColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  bgcolor .
+        ///     Sets the source reference on Chart Studio Cloud for <c>bgcolor</c>.
         /// </summary>
         [JsonPropertyName(@"bgcolorsrc")]
         public string BgColorSrc { get; set;} 
@@ -74,7 +74,7 @@ namespace Plotly.Blazor.Traces.ScatterGlLib
         public IList<object> BorderColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  bordercolor .
+        ///     Sets the source reference on Chart Studio Cloud for <c>bordercolor</c>.
         /// </summary>
         [JsonPropertyName(@"bordercolorsrc")]
         public string BorderColorSrc { get; set;} 
@@ -107,7 +107,7 @@ namespace Plotly.Blazor.Traces.ScatterGlLib
         public IList<int?> NameLengthArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  namelength .
+        ///     Sets the source reference on Chart Studio Cloud for <c>namelength</c>.
         /// </summary>
         [JsonPropertyName(@"namelengthsrc")]
         public string NameLengthSrc { get; set;} 

--- a/Plotly.Blazor/Traces/ScatterGlLib/HoverLabelLib/Font.cs
+++ b/Plotly.Blazor/Traces/ScatterGlLib/HoverLabelLib/Font.cs
@@ -34,7 +34,7 @@ namespace Plotly.Blazor.Traces.ScatterGlLib.HoverLabelLib
         public IList<object> ColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  color .
+        ///     Sets the source reference on Chart Studio Cloud for <c>color</c>.
         /// </summary>
         [JsonPropertyName(@"colorsrc")]
         public string ColorSrc { get; set;} 
@@ -73,7 +73,7 @@ namespace Plotly.Blazor.Traces.ScatterGlLib.HoverLabelLib
         public IList<string> FamilyArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  family .
+        ///     Sets the source reference on Chart Studio Cloud for <c>family</c>.
         /// </summary>
         [JsonPropertyName(@"familysrc")]
         public string FamilySrc { get; set;} 
@@ -92,7 +92,7 @@ namespace Plotly.Blazor.Traces.ScatterGlLib.HoverLabelLib
         public IList<decimal?> SizeArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  size .
+        ///     Sets the source reference on Chart Studio Cloud for <c>size</c>.
         /// </summary>
         [JsonPropertyName(@"sizesrc")]
         public string SizeSrc { get; set;} 

--- a/Plotly.Blazor/Traces/ScatterGlLib/Marker.cs
+++ b/Plotly.Blazor/Traces/ScatterGlLib/Marker.cs
@@ -114,7 +114,7 @@ namespace Plotly.Blazor.Traces.ScatterGlLib
         public object ColorScale { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  color .
+        ///     Sets the source reference on Chart Studio Cloud for <c>color</c>.
         /// </summary>
         [JsonPropertyName(@"colorsrc")]
         public string ColorSrc { get; set;} 
@@ -139,7 +139,7 @@ namespace Plotly.Blazor.Traces.ScatterGlLib
         public IList<decimal?> OpacityArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  opacity .
+        ///     Sets the source reference on Chart Studio Cloud for <c>opacity</c>.
         /// </summary>
         [JsonPropertyName(@"opacitysrc")]
         public string OpacitySrc { get; set;} 
@@ -196,7 +196,7 @@ namespace Plotly.Blazor.Traces.ScatterGlLib
         public decimal? SizeRef { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  size .
+        ///     Sets the source reference on Chart Studio Cloud for <c>size</c>.
         /// </summary>
         [JsonPropertyName(@"sizesrc")]
         public string SizeSrc { get; set;} 
@@ -221,7 +221,7 @@ namespace Plotly.Blazor.Traces.ScatterGlLib
         public IList<Plotly.Blazor.Traces.ScatterGlLib.MarkerLib.SymbolEnum?> SymbolArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  symbol .
+        ///     Sets the source reference on Chart Studio Cloud for <c>symbol</c>.
         /// </summary>
         [JsonPropertyName(@"symbolsrc")]
         public string SymbolSrc { get; set;} 

--- a/Plotly.Blazor/Traces/ScatterGlLib/MarkerLib/Line.cs
+++ b/Plotly.Blazor/Traces/ScatterGlLib/MarkerLib/Line.cs
@@ -110,7 +110,7 @@ namespace Plotly.Blazor.Traces.ScatterGlLib.MarkerLib
         public object ColorScale { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  color .
+        ///     Sets the source reference on Chart Studio Cloud for <c>color</c>.
         /// </summary>
         [JsonPropertyName(@"colorsrc")]
         public string ColorSrc { get; set;} 
@@ -138,7 +138,7 @@ namespace Plotly.Blazor.Traces.ScatterGlLib.MarkerLib
         public IList<decimal?> WidthArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  width .
+        ///     Sets the source reference on Chart Studio Cloud for <c>width</c>.
         /// </summary>
         [JsonPropertyName(@"widthsrc")]
         public string WidthSrc { get; set;} 

--- a/Plotly.Blazor/Traces/ScatterGlLib/TextFont.cs
+++ b/Plotly.Blazor/Traces/ScatterGlLib/TextFont.cs
@@ -34,7 +34,7 @@ namespace Plotly.Blazor.Traces.ScatterGlLib
         public IList<object> ColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  color .
+        ///     Sets the source reference on Chart Studio Cloud for <c>color</c>.
         /// </summary>
         [JsonPropertyName(@"colorsrc")]
         public string ColorSrc { get; set;} 
@@ -73,7 +73,7 @@ namespace Plotly.Blazor.Traces.ScatterGlLib
         public IList<string> FamilyArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  family .
+        ///     Sets the source reference on Chart Studio Cloud for <c>family</c>.
         /// </summary>
         [JsonPropertyName(@"familysrc")]
         public string FamilySrc { get; set;} 
@@ -92,7 +92,7 @@ namespace Plotly.Blazor.Traces.ScatterGlLib
         public IList<decimal?> SizeArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  size .
+        ///     Sets the source reference on Chart Studio Cloud for <c>size</c>.
         /// </summary>
         [JsonPropertyName(@"sizesrc")]
         public string SizeSrc { get; set;} 

--- a/Plotly.Blazor/Traces/ScatterLib/ErrorX.cs
+++ b/Plotly.Blazor/Traces/ScatterLib/ErrorX.cs
@@ -35,13 +35,13 @@ namespace Plotly.Blazor.Traces.ScatterLib
         public IList<object> ArrayMinus { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  arrayminus .
+        ///     Sets the source reference on Chart Studio Cloud for <c>arrayminus</c>.
         /// </summary>
         [JsonPropertyName(@"arrayminussrc")]
         public string ArrayMinusSrc { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  array .
+        ///     Sets the source reference on Chart Studio Cloud for <c>array</c>.
         /// </summary>
         [JsonPropertyName(@"arraysrc")]
         public string ArraySrc { get; set;} 

--- a/Plotly.Blazor/Traces/ScatterLib/ErrorY.cs
+++ b/Plotly.Blazor/Traces/ScatterLib/ErrorY.cs
@@ -35,13 +35,13 @@ namespace Plotly.Blazor.Traces.ScatterLib
         public IList<object> ArrayMinus { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  arrayminus .
+        ///     Sets the source reference on Chart Studio Cloud for <c>arrayminus</c>.
         /// </summary>
         [JsonPropertyName(@"arrayminussrc")]
         public string ArrayMinusSrc { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  array .
+        ///     Sets the source reference on Chart Studio Cloud for <c>array</c>.
         /// </summary>
         [JsonPropertyName(@"arraysrc")]
         public string ArraySrc { get; set;} 

--- a/Plotly.Blazor/Traces/ScatterLib/HoverLabel.cs
+++ b/Plotly.Blazor/Traces/ScatterLib/HoverLabel.cs
@@ -36,7 +36,7 @@ namespace Plotly.Blazor.Traces.ScatterLib
         public IList<Plotly.Blazor.Traces.ScatterLib.HoverLabelLib.AlignEnum?> AlignArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  align .
+        ///     Sets the source reference on Chart Studio Cloud for <c>align</c>.
         /// </summary>
         [JsonPropertyName(@"alignsrc")]
         public string AlignSrc { get; set;} 
@@ -55,7 +55,7 @@ namespace Plotly.Blazor.Traces.ScatterLib
         public IList<object> BgColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  bgcolor .
+        ///     Sets the source reference on Chart Studio Cloud for <c>bgcolor</c>.
         /// </summary>
         [JsonPropertyName(@"bgcolorsrc")]
         public string BgColorSrc { get; set;} 
@@ -74,7 +74,7 @@ namespace Plotly.Blazor.Traces.ScatterLib
         public IList<object> BorderColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  bordercolor .
+        ///     Sets the source reference on Chart Studio Cloud for <c>bordercolor</c>.
         /// </summary>
         [JsonPropertyName(@"bordercolorsrc")]
         public string BorderColorSrc { get; set;} 
@@ -107,7 +107,7 @@ namespace Plotly.Blazor.Traces.ScatterLib
         public IList<int?> NameLengthArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  namelength .
+        ///     Sets the source reference on Chart Studio Cloud for <c>namelength</c>.
         /// </summary>
         [JsonPropertyName(@"namelengthsrc")]
         public string NameLengthSrc { get; set;} 

--- a/Plotly.Blazor/Traces/ScatterLib/HoverLabelLib/Font.cs
+++ b/Plotly.Blazor/Traces/ScatterLib/HoverLabelLib/Font.cs
@@ -34,7 +34,7 @@ namespace Plotly.Blazor.Traces.ScatterLib.HoverLabelLib
         public IList<object> ColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  color .
+        ///     Sets the source reference on Chart Studio Cloud for <c>color</c>.
         /// </summary>
         [JsonPropertyName(@"colorsrc")]
         public string ColorSrc { get; set;} 
@@ -73,7 +73,7 @@ namespace Plotly.Blazor.Traces.ScatterLib.HoverLabelLib
         public IList<string> FamilyArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  family .
+        ///     Sets the source reference on Chart Studio Cloud for <c>family</c>.
         /// </summary>
         [JsonPropertyName(@"familysrc")]
         public string FamilySrc { get; set;} 
@@ -92,7 +92,7 @@ namespace Plotly.Blazor.Traces.ScatterLib.HoverLabelLib
         public IList<decimal?> SizeArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  size .
+        ///     Sets the source reference on Chart Studio Cloud for <c>size</c>.
         /// </summary>
         [JsonPropertyName(@"sizesrc")]
         public string SizeSrc { get; set;} 

--- a/Plotly.Blazor/Traces/ScatterLib/Marker.cs
+++ b/Plotly.Blazor/Traces/ScatterLib/Marker.cs
@@ -114,7 +114,7 @@ namespace Plotly.Blazor.Traces.ScatterLib
         public object ColorScale { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  color .
+        ///     Sets the source reference on Chart Studio Cloud for <c>color</c>.
         /// </summary>
         [JsonPropertyName(@"colorsrc")]
         public string ColorSrc { get; set;} 
@@ -152,7 +152,7 @@ namespace Plotly.Blazor.Traces.ScatterLib
         public IList<decimal?> OpacityArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  opacity .
+        ///     Sets the source reference on Chart Studio Cloud for <c>opacity</c>.
         /// </summary>
         [JsonPropertyName(@"opacitysrc")]
         public string OpacitySrc { get; set;} 
@@ -209,7 +209,7 @@ namespace Plotly.Blazor.Traces.ScatterLib
         public decimal? SizeRef { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  size .
+        ///     Sets the source reference on Chart Studio Cloud for <c>size</c>.
         /// </summary>
         [JsonPropertyName(@"sizesrc")]
         public string SizeSrc { get; set;} 
@@ -234,7 +234,7 @@ namespace Plotly.Blazor.Traces.ScatterLib
         public IList<Plotly.Blazor.Traces.ScatterLib.MarkerLib.SymbolEnum?> SymbolArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  symbol .
+        ///     Sets the source reference on Chart Studio Cloud for <c>symbol</c>.
         /// </summary>
         [JsonPropertyName(@"symbolsrc")]
         public string SymbolSrc { get; set;} 

--- a/Plotly.Blazor/Traces/ScatterLib/MarkerLib/Gradient.cs
+++ b/Plotly.Blazor/Traces/ScatterLib/MarkerLib/Gradient.cs
@@ -36,7 +36,7 @@ namespace Plotly.Blazor.Traces.ScatterLib.MarkerLib
         public IList<object> ColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  color .
+        ///     Sets the source reference on Chart Studio Cloud for <c>color</c>.
         /// </summary>
         [JsonPropertyName(@"colorsrc")]
         public string ColorSrc { get; set;} 
@@ -55,7 +55,7 @@ namespace Plotly.Blazor.Traces.ScatterLib.MarkerLib
         public IList<Plotly.Blazor.Traces.ScatterLib.MarkerLib.GradientLib.TypeEnum?> TypeArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  type .
+        ///     Sets the source reference on Chart Studio Cloud for <c>type</c>.
         /// </summary>
         [JsonPropertyName(@"typesrc")]
         public string TypeSrc { get; set;} 

--- a/Plotly.Blazor/Traces/ScatterLib/MarkerLib/Line.cs
+++ b/Plotly.Blazor/Traces/ScatterLib/MarkerLib/Line.cs
@@ -110,7 +110,7 @@ namespace Plotly.Blazor.Traces.ScatterLib.MarkerLib
         public object ColorScale { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  color .
+        ///     Sets the source reference on Chart Studio Cloud for <c>color</c>.
         /// </summary>
         [JsonPropertyName(@"colorsrc")]
         public string ColorSrc { get; set;} 
@@ -138,7 +138,7 @@ namespace Plotly.Blazor.Traces.ScatterLib.MarkerLib
         public IList<decimal?> WidthArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  width .
+        ///     Sets the source reference on Chart Studio Cloud for <c>width</c>.
         /// </summary>
         [JsonPropertyName(@"widthsrc")]
         public string WidthSrc { get; set;} 

--- a/Plotly.Blazor/Traces/ScatterLib/TextFont.cs
+++ b/Plotly.Blazor/Traces/ScatterLib/TextFont.cs
@@ -34,7 +34,7 @@ namespace Plotly.Blazor.Traces.ScatterLib
         public IList<object> ColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  color .
+        ///     Sets the source reference on Chart Studio Cloud for <c>color</c>.
         /// </summary>
         [JsonPropertyName(@"colorsrc")]
         public string ColorSrc { get; set;} 
@@ -73,7 +73,7 @@ namespace Plotly.Blazor.Traces.ScatterLib
         public IList<string> FamilyArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  family .
+        ///     Sets the source reference on Chart Studio Cloud for <c>family</c>.
         /// </summary>
         [JsonPropertyName(@"familysrc")]
         public string FamilySrc { get; set;} 
@@ -92,7 +92,7 @@ namespace Plotly.Blazor.Traces.ScatterLib
         public IList<decimal?> SizeArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  size .
+        ///     Sets the source reference on Chart Studio Cloud for <c>size</c>.
         /// </summary>
         [JsonPropertyName(@"sizesrc")]
         public string SizeSrc { get; set;} 

--- a/Plotly.Blazor/Traces/ScatterMapBox.cs
+++ b/Plotly.Blazor/Traces/ScatterMapBox.cs
@@ -50,7 +50,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> CustomData { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  customdata .
+        ///     Sets the source reference on Chart Studio Cloud for <c>customdata</c>.
         /// </summary>
         [JsonPropertyName(@"customdatasrc")]
         public string CustomDataSrc { get; set;} 
@@ -88,7 +88,7 @@ namespace Plotly.Blazor.Traces
         public IList<Plotly.Blazor.Traces.ScatterMapBoxLib.HoverInfoFlag?> HoverInfoArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  hoverinfo .
+        ///     Sets the source reference on Chart Studio Cloud for <c>hoverinfo</c>.
         /// </summary>
         [JsonPropertyName(@"hoverinfosrc")]
         public string HoverInfoSrc { get; set;} 
@@ -149,7 +149,7 @@ namespace Plotly.Blazor.Traces
         public IList<string> HoverTemplateArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  hovertemplate .
+        ///     Sets the source reference on Chart Studio Cloud for <c>hovertemplate</c>.
         /// </summary>
         [JsonPropertyName(@"hovertemplatesrc")]
         public string HoverTemplateSrc { get; set;} 
@@ -176,7 +176,7 @@ namespace Plotly.Blazor.Traces
         public IList<string> HoverTextArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  hovertext .
+        ///     Sets the source reference on Chart Studio Cloud for <c>hovertext</c>.
         /// </summary>
         [JsonPropertyName(@"hovertextsrc")]
         public string HoverTextSrc { get; set;} 
@@ -190,7 +190,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> Ids { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  ids .
+        ///     Sets the source reference on Chart Studio Cloud for <c>ids</c>.
         /// </summary>
         [JsonPropertyName(@"idssrc")]
         public string IdsSrc { get; set;} 
@@ -202,7 +202,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> Lat { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  lat .
+        ///     Sets the source reference on Chart Studio Cloud for <c>lat</c>.
         /// </summary>
         [JsonPropertyName(@"latsrc")]
         public string LatSrc { get; set;} 
@@ -243,7 +243,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> Lon { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  lon .
+        ///     Sets the source reference on Chart Studio Cloud for <c>lon</c>.
         /// </summary>
         [JsonPropertyName(@"lonsrc")]
         public string LonSrc { get; set;} 
@@ -284,7 +284,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> MetaArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  meta .
+        ///     Sets the source reference on Chart Studio Cloud for <c>meta</c>.
         /// </summary>
         [JsonPropertyName(@"metasrc")]
         public string MetaSrc { get; set;} 
@@ -382,7 +382,7 @@ namespace Plotly.Blazor.Traces
         public Plotly.Blazor.Traces.ScatterMapBoxLib.TextPositionEnum? TextPosition { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  text .
+        ///     Sets the source reference on Chart Studio Cloud for <c>text</c>.
         /// </summary>
         [JsonPropertyName(@"textsrc")]
         public string TextSrc { get; set;} 
@@ -421,7 +421,7 @@ namespace Plotly.Blazor.Traces
         public IList<string> TextTemplateArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  texttemplate .
+        ///     Sets the source reference on Chart Studio Cloud for <c>texttemplate</c>.
         /// </summary>
         [JsonPropertyName(@"texttemplatesrc")]
         public string TextTemplateSrc { get; set;} 

--- a/Plotly.Blazor/Traces/ScatterMapBoxLib/HoverLabel.cs
+++ b/Plotly.Blazor/Traces/ScatterMapBoxLib/HoverLabel.cs
@@ -36,7 +36,7 @@ namespace Plotly.Blazor.Traces.ScatterMapBoxLib
         public IList<Plotly.Blazor.Traces.ScatterMapBoxLib.HoverLabelLib.AlignEnum?> AlignArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  align .
+        ///     Sets the source reference on Chart Studio Cloud for <c>align</c>.
         /// </summary>
         [JsonPropertyName(@"alignsrc")]
         public string AlignSrc { get; set;} 
@@ -55,7 +55,7 @@ namespace Plotly.Blazor.Traces.ScatterMapBoxLib
         public IList<object> BgColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  bgcolor .
+        ///     Sets the source reference on Chart Studio Cloud for <c>bgcolor</c>.
         /// </summary>
         [JsonPropertyName(@"bgcolorsrc")]
         public string BgColorSrc { get; set;} 
@@ -74,7 +74,7 @@ namespace Plotly.Blazor.Traces.ScatterMapBoxLib
         public IList<object> BorderColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  bordercolor .
+        ///     Sets the source reference on Chart Studio Cloud for <c>bordercolor</c>.
         /// </summary>
         [JsonPropertyName(@"bordercolorsrc")]
         public string BorderColorSrc { get; set;} 
@@ -107,7 +107,7 @@ namespace Plotly.Blazor.Traces.ScatterMapBoxLib
         public IList<int?> NameLengthArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  namelength .
+        ///     Sets the source reference on Chart Studio Cloud for <c>namelength</c>.
         /// </summary>
         [JsonPropertyName(@"namelengthsrc")]
         public string NameLengthSrc { get; set;} 

--- a/Plotly.Blazor/Traces/ScatterMapBoxLib/HoverLabelLib/Font.cs
+++ b/Plotly.Blazor/Traces/ScatterMapBoxLib/HoverLabelLib/Font.cs
@@ -34,7 +34,7 @@ namespace Plotly.Blazor.Traces.ScatterMapBoxLib.HoverLabelLib
         public IList<object> ColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  color .
+        ///     Sets the source reference on Chart Studio Cloud for <c>color</c>.
         /// </summary>
         [JsonPropertyName(@"colorsrc")]
         public string ColorSrc { get; set;} 
@@ -73,7 +73,7 @@ namespace Plotly.Blazor.Traces.ScatterMapBoxLib.HoverLabelLib
         public IList<string> FamilyArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  family .
+        ///     Sets the source reference on Chart Studio Cloud for <c>family</c>.
         /// </summary>
         [JsonPropertyName(@"familysrc")]
         public string FamilySrc { get; set;} 
@@ -92,7 +92,7 @@ namespace Plotly.Blazor.Traces.ScatterMapBoxLib.HoverLabelLib
         public IList<decimal?> SizeArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  size .
+        ///     Sets the source reference on Chart Studio Cloud for <c>size</c>.
         /// </summary>
         [JsonPropertyName(@"sizesrc")]
         public string SizeSrc { get; set;} 

--- a/Plotly.Blazor/Traces/ScatterMapBoxLib/Marker.cs
+++ b/Plotly.Blazor/Traces/ScatterMapBoxLib/Marker.cs
@@ -44,7 +44,7 @@ namespace Plotly.Blazor.Traces.ScatterMapBoxLib
         public IList<decimal?> AngleArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  angle .
+        ///     Sets the source reference on Chart Studio Cloud for <c>angle</c>.
         /// </summary>
         [JsonPropertyName(@"anglesrc")]
         public string AngleSrc { get; set;} 
@@ -143,7 +143,7 @@ namespace Plotly.Blazor.Traces.ScatterMapBoxLib
         public object ColorScale { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  color .
+        ///     Sets the source reference on Chart Studio Cloud for <c>color</c>.
         /// </summary>
         [JsonPropertyName(@"colorsrc")]
         public string ColorSrc { get; set;} 
@@ -162,7 +162,7 @@ namespace Plotly.Blazor.Traces.ScatterMapBoxLib
         public IList<decimal?> OpacityArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  opacity .
+        ///     Sets the source reference on Chart Studio Cloud for <c>opacity</c>.
         /// </summary>
         [JsonPropertyName(@"opacitysrc")]
         public string OpacitySrc { get; set;} 
@@ -219,7 +219,7 @@ namespace Plotly.Blazor.Traces.ScatterMapBoxLib
         public decimal? SizeRef { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  size .
+        ///     Sets the source reference on Chart Studio Cloud for <c>size</c>.
         /// </summary>
         [JsonPropertyName(@"sizesrc")]
         public string SizeSrc { get; set;} 
@@ -242,7 +242,7 @@ namespace Plotly.Blazor.Traces.ScatterMapBoxLib
         public IList<string> SymbolArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  symbol .
+        ///     Sets the source reference on Chart Studio Cloud for <c>symbol</c>.
         /// </summary>
         [JsonPropertyName(@"symbolsrc")]
         public string SymbolSrc { get; set;} 

--- a/Plotly.Blazor/Traces/ScatterPolar.cs
+++ b/Plotly.Blazor/Traces/ScatterPolar.cs
@@ -49,7 +49,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> CustomData { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  customdata .
+        ///     Sets the source reference on Chart Studio Cloud for <c>customdata</c>.
         /// </summary>
         [JsonPropertyName(@"customdatasrc")]
         public string CustomDataSrc { get; set;} 
@@ -104,7 +104,7 @@ namespace Plotly.Blazor.Traces
         public IList<Plotly.Blazor.Traces.ScatterPolarLib.HoverInfoFlag?> HoverInfoArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  hoverinfo .
+        ///     Sets the source reference on Chart Studio Cloud for <c>hoverinfo</c>.
         /// </summary>
         [JsonPropertyName(@"hoverinfosrc")]
         public string HoverInfoSrc { get; set;} 
@@ -174,7 +174,7 @@ namespace Plotly.Blazor.Traces
         public IList<string> HoverTemplateArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  hovertemplate .
+        ///     Sets the source reference on Chart Studio Cloud for <c>hovertemplate</c>.
         /// </summary>
         [JsonPropertyName(@"hovertemplatesrc")]
         public string HoverTemplateSrc { get; set;} 
@@ -199,7 +199,7 @@ namespace Plotly.Blazor.Traces
         public IList<string> HoverTextArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  hovertext .
+        ///     Sets the source reference on Chart Studio Cloud for <c>hovertext</c>.
         /// </summary>
         [JsonPropertyName(@"hovertextsrc")]
         public string HoverTextSrc { get; set;} 
@@ -213,7 +213,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> Ids { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  ids .
+        ///     Sets the source reference on Chart Studio Cloud for <c>ids</c>.
         /// </summary>
         [JsonPropertyName(@"idssrc")]
         public string IdsSrc { get; set;} 
@@ -283,7 +283,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> MetaArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  meta .
+        ///     Sets the source reference on Chart Studio Cloud for <c>meta</c>.
         /// </summary>
         [JsonPropertyName(@"metasrc")]
         public string MetaSrc { get; set;} 
@@ -324,7 +324,7 @@ namespace Plotly.Blazor.Traces
         public object R0 { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  r .
+        ///     Sets the source reference on Chart Studio Cloud for <c>r</c>.
         /// </summary>
         [JsonPropertyName(@"rsrc")]
         public string RSrc { get; set;} 
@@ -409,13 +409,13 @@ namespace Plotly.Blazor.Traces
         public IList<Plotly.Blazor.Traces.ScatterPolarLib.TextPositionEnum?> TextPositionArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  textposition .
+        ///     Sets the source reference on Chart Studio Cloud for <c>textposition</c>.
         /// </summary>
         [JsonPropertyName(@"textpositionsrc")]
         public string TextPositionSrc { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  text .
+        ///     Sets the source reference on Chart Studio Cloud for <c>text</c>.
         /// </summary>
         [JsonPropertyName(@"textsrc")]
         public string TextSrc { get; set;} 
@@ -454,7 +454,7 @@ namespace Plotly.Blazor.Traces
         public IList<string> TextTemplateArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  texttemplate .
+        ///     Sets the source reference on Chart Studio Cloud for <c>texttemplate</c>.
         /// </summary>
         [JsonPropertyName(@"texttemplatesrc")]
         public string TextTemplateSrc { get; set;} 
@@ -474,7 +474,7 @@ namespace Plotly.Blazor.Traces
         public object Theta0 { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  theta .
+        ///     Sets the source reference on Chart Studio Cloud for <c>theta</c>.
         /// </summary>
         [JsonPropertyName(@"thetasrc")]
         public string ThetaSrc { get; set;} 

--- a/Plotly.Blazor/Traces/ScatterPolarGl.cs
+++ b/Plotly.Blazor/Traces/ScatterPolarGl.cs
@@ -41,7 +41,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> CustomData { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  customdata .
+        ///     Sets the source reference on Chart Studio Cloud for <c>customdata</c>.
         /// </summary>
         [JsonPropertyName(@"customdatasrc")]
         public string CustomDataSrc { get; set;} 
@@ -106,7 +106,7 @@ namespace Plotly.Blazor.Traces
         public IList<Plotly.Blazor.Traces.ScatterPolarGlLib.HoverInfoFlag?> HoverInfoArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  hoverinfo .
+        ///     Sets the source reference on Chart Studio Cloud for <c>hoverinfo</c>.
         /// </summary>
         [JsonPropertyName(@"hoverinfosrc")]
         public string HoverInfoSrc { get; set;} 
@@ -167,7 +167,7 @@ namespace Plotly.Blazor.Traces
         public IList<string> HoverTemplateArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  hovertemplate .
+        ///     Sets the source reference on Chart Studio Cloud for <c>hovertemplate</c>.
         /// </summary>
         [JsonPropertyName(@"hovertemplatesrc")]
         public string HoverTemplateSrc { get; set;} 
@@ -192,7 +192,7 @@ namespace Plotly.Blazor.Traces
         public IList<string> HoverTextArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  hovertext .
+        ///     Sets the source reference on Chart Studio Cloud for <c>hovertext</c>.
         /// </summary>
         [JsonPropertyName(@"hovertextsrc")]
         public string HoverTextSrc { get; set;} 
@@ -206,7 +206,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> Ids { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  ids .
+        ///     Sets the source reference on Chart Studio Cloud for <c>ids</c>.
         /// </summary>
         [JsonPropertyName(@"idssrc")]
         public string IdsSrc { get; set;} 
@@ -276,7 +276,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> MetaArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  meta .
+        ///     Sets the source reference on Chart Studio Cloud for <c>meta</c>.
         /// </summary>
         [JsonPropertyName(@"metasrc")]
         public string MetaSrc { get; set;} 
@@ -317,7 +317,7 @@ namespace Plotly.Blazor.Traces
         public object R0 { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  r .
+        ///     Sets the source reference on Chart Studio Cloud for <c>r</c>.
         /// </summary>
         [JsonPropertyName(@"rsrc")]
         public string RSrc { get; set;} 
@@ -402,13 +402,13 @@ namespace Plotly.Blazor.Traces
         public IList<Plotly.Blazor.Traces.ScatterPolarGlLib.TextPositionEnum?> TextPositionArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  textposition .
+        ///     Sets the source reference on Chart Studio Cloud for <c>textposition</c>.
         /// </summary>
         [JsonPropertyName(@"textpositionsrc")]
         public string TextPositionSrc { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  text .
+        ///     Sets the source reference on Chart Studio Cloud for <c>text</c>.
         /// </summary>
         [JsonPropertyName(@"textsrc")]
         public string TextSrc { get; set;} 
@@ -447,7 +447,7 @@ namespace Plotly.Blazor.Traces
         public IList<string> TextTemplateArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  texttemplate .
+        ///     Sets the source reference on Chart Studio Cloud for <c>texttemplate</c>.
         /// </summary>
         [JsonPropertyName(@"texttemplatesrc")]
         public string TextTemplateSrc { get; set;} 
@@ -467,7 +467,7 @@ namespace Plotly.Blazor.Traces
         public object Theta0 { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  theta .
+        ///     Sets the source reference on Chart Studio Cloud for <c>theta</c>.
         /// </summary>
         [JsonPropertyName(@"thetasrc")]
         public string ThetaSrc { get; set;} 

--- a/Plotly.Blazor/Traces/ScatterPolarGlLib/HoverLabel.cs
+++ b/Plotly.Blazor/Traces/ScatterPolarGlLib/HoverLabel.cs
@@ -36,7 +36,7 @@ namespace Plotly.Blazor.Traces.ScatterPolarGlLib
         public IList<Plotly.Blazor.Traces.ScatterPolarGlLib.HoverLabelLib.AlignEnum?> AlignArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  align .
+        ///     Sets the source reference on Chart Studio Cloud for <c>align</c>.
         /// </summary>
         [JsonPropertyName(@"alignsrc")]
         public string AlignSrc { get; set;} 
@@ -55,7 +55,7 @@ namespace Plotly.Blazor.Traces.ScatterPolarGlLib
         public IList<object> BgColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  bgcolor .
+        ///     Sets the source reference on Chart Studio Cloud for <c>bgcolor</c>.
         /// </summary>
         [JsonPropertyName(@"bgcolorsrc")]
         public string BgColorSrc { get; set;} 
@@ -74,7 +74,7 @@ namespace Plotly.Blazor.Traces.ScatterPolarGlLib
         public IList<object> BorderColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  bordercolor .
+        ///     Sets the source reference on Chart Studio Cloud for <c>bordercolor</c>.
         /// </summary>
         [JsonPropertyName(@"bordercolorsrc")]
         public string BorderColorSrc { get; set;} 
@@ -107,7 +107,7 @@ namespace Plotly.Blazor.Traces.ScatterPolarGlLib
         public IList<int?> NameLengthArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  namelength .
+        ///     Sets the source reference on Chart Studio Cloud for <c>namelength</c>.
         /// </summary>
         [JsonPropertyName(@"namelengthsrc")]
         public string NameLengthSrc { get; set;} 

--- a/Plotly.Blazor/Traces/ScatterPolarGlLib/HoverLabelLib/Font.cs
+++ b/Plotly.Blazor/Traces/ScatterPolarGlLib/HoverLabelLib/Font.cs
@@ -34,7 +34,7 @@ namespace Plotly.Blazor.Traces.ScatterPolarGlLib.HoverLabelLib
         public IList<object> ColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  color .
+        ///     Sets the source reference on Chart Studio Cloud for <c>color</c>.
         /// </summary>
         [JsonPropertyName(@"colorsrc")]
         public string ColorSrc { get; set;} 
@@ -73,7 +73,7 @@ namespace Plotly.Blazor.Traces.ScatterPolarGlLib.HoverLabelLib
         public IList<string> FamilyArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  family .
+        ///     Sets the source reference on Chart Studio Cloud for <c>family</c>.
         /// </summary>
         [JsonPropertyName(@"familysrc")]
         public string FamilySrc { get; set;} 
@@ -92,7 +92,7 @@ namespace Plotly.Blazor.Traces.ScatterPolarGlLib.HoverLabelLib
         public IList<decimal?> SizeArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  size .
+        ///     Sets the source reference on Chart Studio Cloud for <c>size</c>.
         /// </summary>
         [JsonPropertyName(@"sizesrc")]
         public string SizeSrc { get; set;} 

--- a/Plotly.Blazor/Traces/ScatterPolarGlLib/Marker.cs
+++ b/Plotly.Blazor/Traces/ScatterPolarGlLib/Marker.cs
@@ -114,7 +114,7 @@ namespace Plotly.Blazor.Traces.ScatterPolarGlLib
         public object ColorScale { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  color .
+        ///     Sets the source reference on Chart Studio Cloud for <c>color</c>.
         /// </summary>
         [JsonPropertyName(@"colorsrc")]
         public string ColorSrc { get; set;} 
@@ -139,7 +139,7 @@ namespace Plotly.Blazor.Traces.ScatterPolarGlLib
         public IList<decimal?> OpacityArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  opacity .
+        ///     Sets the source reference on Chart Studio Cloud for <c>opacity</c>.
         /// </summary>
         [JsonPropertyName(@"opacitysrc")]
         public string OpacitySrc { get; set;} 
@@ -196,7 +196,7 @@ namespace Plotly.Blazor.Traces.ScatterPolarGlLib
         public decimal? SizeRef { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  size .
+        ///     Sets the source reference on Chart Studio Cloud for <c>size</c>.
         /// </summary>
         [JsonPropertyName(@"sizesrc")]
         public string SizeSrc { get; set;} 
@@ -221,7 +221,7 @@ namespace Plotly.Blazor.Traces.ScatterPolarGlLib
         public IList<Plotly.Blazor.Traces.ScatterPolarGlLib.MarkerLib.SymbolEnum?> SymbolArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  symbol .
+        ///     Sets the source reference on Chart Studio Cloud for <c>symbol</c>.
         /// </summary>
         [JsonPropertyName(@"symbolsrc")]
         public string SymbolSrc { get; set;} 

--- a/Plotly.Blazor/Traces/ScatterPolarGlLib/MarkerLib/Line.cs
+++ b/Plotly.Blazor/Traces/ScatterPolarGlLib/MarkerLib/Line.cs
@@ -110,7 +110,7 @@ namespace Plotly.Blazor.Traces.ScatterPolarGlLib.MarkerLib
         public object ColorScale { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  color .
+        ///     Sets the source reference on Chart Studio Cloud for <c>color</c>.
         /// </summary>
         [JsonPropertyName(@"colorsrc")]
         public string ColorSrc { get; set;} 
@@ -138,7 +138,7 @@ namespace Plotly.Blazor.Traces.ScatterPolarGlLib.MarkerLib
         public IList<decimal?> WidthArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  width .
+        ///     Sets the source reference on Chart Studio Cloud for <c>width</c>.
         /// </summary>
         [JsonPropertyName(@"widthsrc")]
         public string WidthSrc { get; set;} 

--- a/Plotly.Blazor/Traces/ScatterPolarGlLib/TextFont.cs
+++ b/Plotly.Blazor/Traces/ScatterPolarGlLib/TextFont.cs
@@ -34,7 +34,7 @@ namespace Plotly.Blazor.Traces.ScatterPolarGlLib
         public IList<object> ColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  color .
+        ///     Sets the source reference on Chart Studio Cloud for <c>color</c>.
         /// </summary>
         [JsonPropertyName(@"colorsrc")]
         public string ColorSrc { get; set;} 
@@ -73,7 +73,7 @@ namespace Plotly.Blazor.Traces.ScatterPolarGlLib
         public IList<string> FamilyArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  family .
+        ///     Sets the source reference on Chart Studio Cloud for <c>family</c>.
         /// </summary>
         [JsonPropertyName(@"familysrc")]
         public string FamilySrc { get; set;} 
@@ -92,7 +92,7 @@ namespace Plotly.Blazor.Traces.ScatterPolarGlLib
         public IList<decimal?> SizeArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  size .
+        ///     Sets the source reference on Chart Studio Cloud for <c>size</c>.
         /// </summary>
         [JsonPropertyName(@"sizesrc")]
         public string SizeSrc { get; set;} 

--- a/Plotly.Blazor/Traces/ScatterPolarLib/HoverLabel.cs
+++ b/Plotly.Blazor/Traces/ScatterPolarLib/HoverLabel.cs
@@ -36,7 +36,7 @@ namespace Plotly.Blazor.Traces.ScatterPolarLib
         public IList<Plotly.Blazor.Traces.ScatterPolarLib.HoverLabelLib.AlignEnum?> AlignArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  align .
+        ///     Sets the source reference on Chart Studio Cloud for <c>align</c>.
         /// </summary>
         [JsonPropertyName(@"alignsrc")]
         public string AlignSrc { get; set;} 
@@ -55,7 +55,7 @@ namespace Plotly.Blazor.Traces.ScatterPolarLib
         public IList<object> BgColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  bgcolor .
+        ///     Sets the source reference on Chart Studio Cloud for <c>bgcolor</c>.
         /// </summary>
         [JsonPropertyName(@"bgcolorsrc")]
         public string BgColorSrc { get; set;} 
@@ -74,7 +74,7 @@ namespace Plotly.Blazor.Traces.ScatterPolarLib
         public IList<object> BorderColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  bordercolor .
+        ///     Sets the source reference on Chart Studio Cloud for <c>bordercolor</c>.
         /// </summary>
         [JsonPropertyName(@"bordercolorsrc")]
         public string BorderColorSrc { get; set;} 
@@ -107,7 +107,7 @@ namespace Plotly.Blazor.Traces.ScatterPolarLib
         public IList<int?> NameLengthArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  namelength .
+        ///     Sets the source reference on Chart Studio Cloud for <c>namelength</c>.
         /// </summary>
         [JsonPropertyName(@"namelengthsrc")]
         public string NameLengthSrc { get; set;} 

--- a/Plotly.Blazor/Traces/ScatterPolarLib/HoverLabelLib/Font.cs
+++ b/Plotly.Blazor/Traces/ScatterPolarLib/HoverLabelLib/Font.cs
@@ -34,7 +34,7 @@ namespace Plotly.Blazor.Traces.ScatterPolarLib.HoverLabelLib
         public IList<object> ColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  color .
+        ///     Sets the source reference on Chart Studio Cloud for <c>color</c>.
         /// </summary>
         [JsonPropertyName(@"colorsrc")]
         public string ColorSrc { get; set;} 
@@ -73,7 +73,7 @@ namespace Plotly.Blazor.Traces.ScatterPolarLib.HoverLabelLib
         public IList<string> FamilyArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  family .
+        ///     Sets the source reference on Chart Studio Cloud for <c>family</c>.
         /// </summary>
         [JsonPropertyName(@"familysrc")]
         public string FamilySrc { get; set;} 
@@ -92,7 +92,7 @@ namespace Plotly.Blazor.Traces.ScatterPolarLib.HoverLabelLib
         public IList<decimal?> SizeArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  size .
+        ///     Sets the source reference on Chart Studio Cloud for <c>size</c>.
         /// </summary>
         [JsonPropertyName(@"sizesrc")]
         public string SizeSrc { get; set;} 

--- a/Plotly.Blazor/Traces/ScatterPolarLib/Marker.cs
+++ b/Plotly.Blazor/Traces/ScatterPolarLib/Marker.cs
@@ -114,7 +114,7 @@ namespace Plotly.Blazor.Traces.ScatterPolarLib
         public object ColorScale { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  color .
+        ///     Sets the source reference on Chart Studio Cloud for <c>color</c>.
         /// </summary>
         [JsonPropertyName(@"colorsrc")]
         public string ColorSrc { get; set;} 
@@ -152,7 +152,7 @@ namespace Plotly.Blazor.Traces.ScatterPolarLib
         public IList<decimal?> OpacityArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  opacity .
+        ///     Sets the source reference on Chart Studio Cloud for <c>opacity</c>.
         /// </summary>
         [JsonPropertyName(@"opacitysrc")]
         public string OpacitySrc { get; set;} 
@@ -209,7 +209,7 @@ namespace Plotly.Blazor.Traces.ScatterPolarLib
         public decimal? SizeRef { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  size .
+        ///     Sets the source reference on Chart Studio Cloud for <c>size</c>.
         /// </summary>
         [JsonPropertyName(@"sizesrc")]
         public string SizeSrc { get; set;} 
@@ -234,7 +234,7 @@ namespace Plotly.Blazor.Traces.ScatterPolarLib
         public IList<Plotly.Blazor.Traces.ScatterPolarLib.MarkerLib.SymbolEnum?> SymbolArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  symbol .
+        ///     Sets the source reference on Chart Studio Cloud for <c>symbol</c>.
         /// </summary>
         [JsonPropertyName(@"symbolsrc")]
         public string SymbolSrc { get; set;} 

--- a/Plotly.Blazor/Traces/ScatterPolarLib/MarkerLib/Gradient.cs
+++ b/Plotly.Blazor/Traces/ScatterPolarLib/MarkerLib/Gradient.cs
@@ -36,7 +36,7 @@ namespace Plotly.Blazor.Traces.ScatterPolarLib.MarkerLib
         public IList<object> ColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  color .
+        ///     Sets the source reference on Chart Studio Cloud for <c>color</c>.
         /// </summary>
         [JsonPropertyName(@"colorsrc")]
         public string ColorSrc { get; set;} 
@@ -55,7 +55,7 @@ namespace Plotly.Blazor.Traces.ScatterPolarLib.MarkerLib
         public IList<Plotly.Blazor.Traces.ScatterPolarLib.MarkerLib.GradientLib.TypeEnum?> TypeArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  type .
+        ///     Sets the source reference on Chart Studio Cloud for <c>type</c>.
         /// </summary>
         [JsonPropertyName(@"typesrc")]
         public string TypeSrc { get; set;} 

--- a/Plotly.Blazor/Traces/ScatterPolarLib/MarkerLib/Line.cs
+++ b/Plotly.Blazor/Traces/ScatterPolarLib/MarkerLib/Line.cs
@@ -110,7 +110,7 @@ namespace Plotly.Blazor.Traces.ScatterPolarLib.MarkerLib
         public object ColorScale { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  color .
+        ///     Sets the source reference on Chart Studio Cloud for <c>color</c>.
         /// </summary>
         [JsonPropertyName(@"colorsrc")]
         public string ColorSrc { get; set;} 
@@ -138,7 +138,7 @@ namespace Plotly.Blazor.Traces.ScatterPolarLib.MarkerLib
         public IList<decimal?> WidthArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  width .
+        ///     Sets the source reference on Chart Studio Cloud for <c>width</c>.
         /// </summary>
         [JsonPropertyName(@"widthsrc")]
         public string WidthSrc { get; set;} 

--- a/Plotly.Blazor/Traces/ScatterPolarLib/TextFont.cs
+++ b/Plotly.Blazor/Traces/ScatterPolarLib/TextFont.cs
@@ -34,7 +34,7 @@ namespace Plotly.Blazor.Traces.ScatterPolarLib
         public IList<object> ColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  color .
+        ///     Sets the source reference on Chart Studio Cloud for <c>color</c>.
         /// </summary>
         [JsonPropertyName(@"colorsrc")]
         public string ColorSrc { get; set;} 
@@ -73,7 +73,7 @@ namespace Plotly.Blazor.Traces.ScatterPolarLib
         public IList<string> FamilyArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  family .
+        ///     Sets the source reference on Chart Studio Cloud for <c>family</c>.
         /// </summary>
         [JsonPropertyName(@"familysrc")]
         public string FamilySrc { get; set;} 
@@ -92,7 +92,7 @@ namespace Plotly.Blazor.Traces.ScatterPolarLib
         public IList<decimal?> SizeArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  size .
+        ///     Sets the source reference on Chart Studio Cloud for <c>size</c>.
         /// </summary>
         [JsonPropertyName(@"sizesrc")]
         public string SizeSrc { get; set;} 

--- a/Plotly.Blazor/Traces/ScatterTernary.cs
+++ b/Plotly.Blazor/Traces/ScatterTernary.cs
@@ -35,7 +35,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> A { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  a .
+        ///     Sets the source reference on Chart Studio Cloud for <c>a</c>.
         /// </summary>
         [JsonPropertyName(@"asrc")]
         public string ASrc { get; set;} 
@@ -50,7 +50,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> B { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  b .
+        ///     Sets the source reference on Chart Studio Cloud for <c>b</c>.
         /// </summary>
         [JsonPropertyName(@"bsrc")]
         public string BSrc { get; set;} 
@@ -80,7 +80,7 @@ namespace Plotly.Blazor.Traces
         public bool? ConnectGaps { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  c .
+        ///     Sets the source reference on Chart Studio Cloud for <c>c</c>.
         /// </summary>
         [JsonPropertyName(@"csrc")]
         public string CSrc { get; set;} 
@@ -94,7 +94,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> CustomData { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  customdata .
+        ///     Sets the source reference on Chart Studio Cloud for <c>customdata</c>.
         /// </summary>
         [JsonPropertyName(@"customdatasrc")]
         public string CustomDataSrc { get; set;} 
@@ -136,7 +136,7 @@ namespace Plotly.Blazor.Traces
         public IList<Plotly.Blazor.Traces.ScatterTernaryLib.HoverInfoFlag?> HoverInfoArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  hoverinfo .
+        ///     Sets the source reference on Chart Studio Cloud for <c>hoverinfo</c>.
         /// </summary>
         [JsonPropertyName(@"hoverinfosrc")]
         public string HoverInfoSrc { get; set;} 
@@ -206,7 +206,7 @@ namespace Plotly.Blazor.Traces
         public IList<string> HoverTemplateArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  hovertemplate .
+        ///     Sets the source reference on Chart Studio Cloud for <c>hovertemplate</c>.
         /// </summary>
         [JsonPropertyName(@"hovertemplatesrc")]
         public string HoverTemplateSrc { get; set;} 
@@ -231,7 +231,7 @@ namespace Plotly.Blazor.Traces
         public IList<string> HoverTextArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  hovertext .
+        ///     Sets the source reference on Chart Studio Cloud for <c>hovertext</c>.
         /// </summary>
         [JsonPropertyName(@"hovertextsrc")]
         public string HoverTextSrc { get; set;} 
@@ -245,7 +245,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> Ids { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  ids .
+        ///     Sets the source reference on Chart Studio Cloud for <c>ids</c>.
         /// </summary>
         [JsonPropertyName(@"idssrc")]
         public string IdsSrc { get; set;} 
@@ -315,7 +315,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> MetaArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  meta .
+        ///     Sets the source reference on Chart Studio Cloud for <c>meta</c>.
         /// </summary>
         [JsonPropertyName(@"metasrc")]
         public string MetaSrc { get; set;} 
@@ -431,13 +431,13 @@ namespace Plotly.Blazor.Traces
         public IList<Plotly.Blazor.Traces.ScatterTernaryLib.TextPositionEnum?> TextPositionArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  textposition .
+        ///     Sets the source reference on Chart Studio Cloud for <c>textposition</c>.
         /// </summary>
         [JsonPropertyName(@"textpositionsrc")]
         public string TextPositionSrc { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  text .
+        ///     Sets the source reference on Chart Studio Cloud for <c>text</c>.
         /// </summary>
         [JsonPropertyName(@"textsrc")]
         public string TextSrc { get; set;} 
@@ -476,7 +476,7 @@ namespace Plotly.Blazor.Traces
         public IList<string> TextTemplateArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  texttemplate .
+        ///     Sets the source reference on Chart Studio Cloud for <c>texttemplate</c>.
         /// </summary>
         [JsonPropertyName(@"texttemplatesrc")]
         public string TextTemplateSrc { get; set;} 

--- a/Plotly.Blazor/Traces/ScatterTernaryLib/HoverLabel.cs
+++ b/Plotly.Blazor/Traces/ScatterTernaryLib/HoverLabel.cs
@@ -36,7 +36,7 @@ namespace Plotly.Blazor.Traces.ScatterTernaryLib
         public IList<Plotly.Blazor.Traces.ScatterTernaryLib.HoverLabelLib.AlignEnum?> AlignArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  align .
+        ///     Sets the source reference on Chart Studio Cloud for <c>align</c>.
         /// </summary>
         [JsonPropertyName(@"alignsrc")]
         public string AlignSrc { get; set;} 
@@ -55,7 +55,7 @@ namespace Plotly.Blazor.Traces.ScatterTernaryLib
         public IList<object> BgColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  bgcolor .
+        ///     Sets the source reference on Chart Studio Cloud for <c>bgcolor</c>.
         /// </summary>
         [JsonPropertyName(@"bgcolorsrc")]
         public string BgColorSrc { get; set;} 
@@ -74,7 +74,7 @@ namespace Plotly.Blazor.Traces.ScatterTernaryLib
         public IList<object> BorderColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  bordercolor .
+        ///     Sets the source reference on Chart Studio Cloud for <c>bordercolor</c>.
         /// </summary>
         [JsonPropertyName(@"bordercolorsrc")]
         public string BorderColorSrc { get; set;} 
@@ -107,7 +107,7 @@ namespace Plotly.Blazor.Traces.ScatterTernaryLib
         public IList<int?> NameLengthArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  namelength .
+        ///     Sets the source reference on Chart Studio Cloud for <c>namelength</c>.
         /// </summary>
         [JsonPropertyName(@"namelengthsrc")]
         public string NameLengthSrc { get; set;} 

--- a/Plotly.Blazor/Traces/ScatterTernaryLib/HoverLabelLib/Font.cs
+++ b/Plotly.Blazor/Traces/ScatterTernaryLib/HoverLabelLib/Font.cs
@@ -34,7 +34,7 @@ namespace Plotly.Blazor.Traces.ScatterTernaryLib.HoverLabelLib
         public IList<object> ColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  color .
+        ///     Sets the source reference on Chart Studio Cloud for <c>color</c>.
         /// </summary>
         [JsonPropertyName(@"colorsrc")]
         public string ColorSrc { get; set;} 
@@ -73,7 +73,7 @@ namespace Plotly.Blazor.Traces.ScatterTernaryLib.HoverLabelLib
         public IList<string> FamilyArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  family .
+        ///     Sets the source reference on Chart Studio Cloud for <c>family</c>.
         /// </summary>
         [JsonPropertyName(@"familysrc")]
         public string FamilySrc { get; set;} 
@@ -92,7 +92,7 @@ namespace Plotly.Blazor.Traces.ScatterTernaryLib.HoverLabelLib
         public IList<decimal?> SizeArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  size .
+        ///     Sets the source reference on Chart Studio Cloud for <c>size</c>.
         /// </summary>
         [JsonPropertyName(@"sizesrc")]
         public string SizeSrc { get; set;} 

--- a/Plotly.Blazor/Traces/ScatterTernaryLib/Marker.cs
+++ b/Plotly.Blazor/Traces/ScatterTernaryLib/Marker.cs
@@ -114,7 +114,7 @@ namespace Plotly.Blazor.Traces.ScatterTernaryLib
         public object ColorScale { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  color .
+        ///     Sets the source reference on Chart Studio Cloud for <c>color</c>.
         /// </summary>
         [JsonPropertyName(@"colorsrc")]
         public string ColorSrc { get; set;} 
@@ -152,7 +152,7 @@ namespace Plotly.Blazor.Traces.ScatterTernaryLib
         public IList<decimal?> OpacityArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  opacity .
+        ///     Sets the source reference on Chart Studio Cloud for <c>opacity</c>.
         /// </summary>
         [JsonPropertyName(@"opacitysrc")]
         public string OpacitySrc { get; set;} 
@@ -209,7 +209,7 @@ namespace Plotly.Blazor.Traces.ScatterTernaryLib
         public decimal? SizeRef { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  size .
+        ///     Sets the source reference on Chart Studio Cloud for <c>size</c>.
         /// </summary>
         [JsonPropertyName(@"sizesrc")]
         public string SizeSrc { get; set;} 
@@ -234,7 +234,7 @@ namespace Plotly.Blazor.Traces.ScatterTernaryLib
         public IList<Plotly.Blazor.Traces.ScatterTernaryLib.MarkerLib.SymbolEnum?> SymbolArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  symbol .
+        ///     Sets the source reference on Chart Studio Cloud for <c>symbol</c>.
         /// </summary>
         [JsonPropertyName(@"symbolsrc")]
         public string SymbolSrc { get; set;} 

--- a/Plotly.Blazor/Traces/ScatterTernaryLib/MarkerLib/Gradient.cs
+++ b/Plotly.Blazor/Traces/ScatterTernaryLib/MarkerLib/Gradient.cs
@@ -36,7 +36,7 @@ namespace Plotly.Blazor.Traces.ScatterTernaryLib.MarkerLib
         public IList<object> ColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  color .
+        ///     Sets the source reference on Chart Studio Cloud for <c>color</c>.
         /// </summary>
         [JsonPropertyName(@"colorsrc")]
         public string ColorSrc { get; set;} 
@@ -55,7 +55,7 @@ namespace Plotly.Blazor.Traces.ScatterTernaryLib.MarkerLib
         public IList<Plotly.Blazor.Traces.ScatterTernaryLib.MarkerLib.GradientLib.TypeEnum?> TypeArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  type .
+        ///     Sets the source reference on Chart Studio Cloud for <c>type</c>.
         /// </summary>
         [JsonPropertyName(@"typesrc")]
         public string TypeSrc { get; set;} 

--- a/Plotly.Blazor/Traces/ScatterTernaryLib/MarkerLib/Line.cs
+++ b/Plotly.Blazor/Traces/ScatterTernaryLib/MarkerLib/Line.cs
@@ -110,7 +110,7 @@ namespace Plotly.Blazor.Traces.ScatterTernaryLib.MarkerLib
         public object ColorScale { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  color .
+        ///     Sets the source reference on Chart Studio Cloud for <c>color</c>.
         /// </summary>
         [JsonPropertyName(@"colorsrc")]
         public string ColorSrc { get; set;} 
@@ -138,7 +138,7 @@ namespace Plotly.Blazor.Traces.ScatterTernaryLib.MarkerLib
         public IList<decimal?> WidthArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  width .
+        ///     Sets the source reference on Chart Studio Cloud for <c>width</c>.
         /// </summary>
         [JsonPropertyName(@"widthsrc")]
         public string WidthSrc { get; set;} 

--- a/Plotly.Blazor/Traces/ScatterTernaryLib/TextFont.cs
+++ b/Plotly.Blazor/Traces/ScatterTernaryLib/TextFont.cs
@@ -34,7 +34,7 @@ namespace Plotly.Blazor.Traces.ScatterTernaryLib
         public IList<object> ColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  color .
+        ///     Sets the source reference on Chart Studio Cloud for <c>color</c>.
         /// </summary>
         [JsonPropertyName(@"colorsrc")]
         public string ColorSrc { get; set;} 
@@ -73,7 +73,7 @@ namespace Plotly.Blazor.Traces.ScatterTernaryLib
         public IList<string> FamilyArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  family .
+        ///     Sets the source reference on Chart Studio Cloud for <c>family</c>.
         /// </summary>
         [JsonPropertyName(@"familysrc")]
         public string FamilySrc { get; set;} 
@@ -92,7 +92,7 @@ namespace Plotly.Blazor.Traces.ScatterTernaryLib
         public IList<decimal?> SizeArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  size .
+        ///     Sets the source reference on Chart Studio Cloud for <c>size</c>.
         /// </summary>
         [JsonPropertyName(@"sizesrc")]
         public string SizeSrc { get; set;} 

--- a/Plotly.Blazor/Traces/Splom.cs
+++ b/Plotly.Blazor/Traces/Splom.cs
@@ -34,7 +34,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> CustomData { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  customdata .
+        ///     Sets the source reference on Chart Studio Cloud for <c>customdata</c>.
         /// </summary>
         [JsonPropertyName(@"customdatasrc")]
         public string CustomDataSrc { get; set;} 
@@ -69,7 +69,7 @@ namespace Plotly.Blazor.Traces
         public IList<Plotly.Blazor.Traces.SplomLib.HoverInfoFlag?> HoverInfoArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  hoverinfo .
+        ///     Sets the source reference on Chart Studio Cloud for <c>hoverinfo</c>.
         /// </summary>
         [JsonPropertyName(@"hoverinfosrc")]
         public string HoverInfoSrc { get; set;} 
@@ -130,7 +130,7 @@ namespace Plotly.Blazor.Traces
         public IList<string> HoverTemplateArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  hovertemplate .
+        ///     Sets the source reference on Chart Studio Cloud for <c>hovertemplate</c>.
         /// </summary>
         [JsonPropertyName(@"hovertemplatesrc")]
         public string HoverTemplateSrc { get; set;} 
@@ -149,7 +149,7 @@ namespace Plotly.Blazor.Traces
         public IList<string> HoverTextArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  hovertext .
+        ///     Sets the source reference on Chart Studio Cloud for <c>hovertext</c>.
         /// </summary>
         [JsonPropertyName(@"hovertextsrc")]
         public string HoverTextSrc { get; set;} 
@@ -163,7 +163,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> Ids { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  ids .
+        ///     Sets the source reference on Chart Studio Cloud for <c>ids</c>.
         /// </summary>
         [JsonPropertyName(@"idssrc")]
         public string IdsSrc { get; set;} 
@@ -227,7 +227,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> MetaArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  meta .
+        ///     Sets the source reference on Chart Studio Cloud for <c>meta</c>.
         /// </summary>
         [JsonPropertyName(@"metasrc")]
         public string MetaSrc { get; set;} 
@@ -307,7 +307,7 @@ namespace Plotly.Blazor.Traces
         public IList<string> TextArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  text .
+        ///     Sets the source reference on Chart Studio Cloud for <c>text</c>.
         /// </summary>
         [JsonPropertyName(@"textsrc")]
         public string TextSrc { get; set;} 

--- a/Plotly.Blazor/Traces/SplomLib/Dimension.cs
+++ b/Plotly.Blazor/Traces/SplomLib/Dimension.cs
@@ -61,7 +61,7 @@ namespace Plotly.Blazor.Traces.SplomLib
         public IList<object> Values { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  values .
+        ///     Sets the source reference on Chart Studio Cloud for <c>values</c>.
         /// </summary>
         [JsonPropertyName(@"valuessrc")]
         public string ValuesSrc { get; set;} 

--- a/Plotly.Blazor/Traces/SplomLib/HoverLabel.cs
+++ b/Plotly.Blazor/Traces/SplomLib/HoverLabel.cs
@@ -36,7 +36,7 @@ namespace Plotly.Blazor.Traces.SplomLib
         public IList<Plotly.Blazor.Traces.SplomLib.HoverLabelLib.AlignEnum?> AlignArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  align .
+        ///     Sets the source reference on Chart Studio Cloud for <c>align</c>.
         /// </summary>
         [JsonPropertyName(@"alignsrc")]
         public string AlignSrc { get; set;} 
@@ -55,7 +55,7 @@ namespace Plotly.Blazor.Traces.SplomLib
         public IList<object> BgColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  bgcolor .
+        ///     Sets the source reference on Chart Studio Cloud for <c>bgcolor</c>.
         /// </summary>
         [JsonPropertyName(@"bgcolorsrc")]
         public string BgColorSrc { get; set;} 
@@ -74,7 +74,7 @@ namespace Plotly.Blazor.Traces.SplomLib
         public IList<object> BorderColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  bordercolor .
+        ///     Sets the source reference on Chart Studio Cloud for <c>bordercolor</c>.
         /// </summary>
         [JsonPropertyName(@"bordercolorsrc")]
         public string BorderColorSrc { get; set;} 
@@ -107,7 +107,7 @@ namespace Plotly.Blazor.Traces.SplomLib
         public IList<int?> NameLengthArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  namelength .
+        ///     Sets the source reference on Chart Studio Cloud for <c>namelength</c>.
         /// </summary>
         [JsonPropertyName(@"namelengthsrc")]
         public string NameLengthSrc { get; set;} 

--- a/Plotly.Blazor/Traces/SplomLib/HoverLabelLib/Font.cs
+++ b/Plotly.Blazor/Traces/SplomLib/HoverLabelLib/Font.cs
@@ -34,7 +34,7 @@ namespace Plotly.Blazor.Traces.SplomLib.HoverLabelLib
         public IList<object> ColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  color .
+        ///     Sets the source reference on Chart Studio Cloud for <c>color</c>.
         /// </summary>
         [JsonPropertyName(@"colorsrc")]
         public string ColorSrc { get; set;} 
@@ -73,7 +73,7 @@ namespace Plotly.Blazor.Traces.SplomLib.HoverLabelLib
         public IList<string> FamilyArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  family .
+        ///     Sets the source reference on Chart Studio Cloud for <c>family</c>.
         /// </summary>
         [JsonPropertyName(@"familysrc")]
         public string FamilySrc { get; set;} 
@@ -92,7 +92,7 @@ namespace Plotly.Blazor.Traces.SplomLib.HoverLabelLib
         public IList<decimal?> SizeArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  size .
+        ///     Sets the source reference on Chart Studio Cloud for <c>size</c>.
         /// </summary>
         [JsonPropertyName(@"sizesrc")]
         public string SizeSrc { get; set;} 

--- a/Plotly.Blazor/Traces/SplomLib/Marker.cs
+++ b/Plotly.Blazor/Traces/SplomLib/Marker.cs
@@ -114,7 +114,7 @@ namespace Plotly.Blazor.Traces.SplomLib
         public object ColorScale { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  color .
+        ///     Sets the source reference on Chart Studio Cloud for <c>color</c>.
         /// </summary>
         [JsonPropertyName(@"colorsrc")]
         public string ColorSrc { get; set;} 
@@ -139,7 +139,7 @@ namespace Plotly.Blazor.Traces.SplomLib
         public IList<decimal?> OpacityArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  opacity .
+        ///     Sets the source reference on Chart Studio Cloud for <c>opacity</c>.
         /// </summary>
         [JsonPropertyName(@"opacitysrc")]
         public string OpacitySrc { get; set;} 
@@ -196,7 +196,7 @@ namespace Plotly.Blazor.Traces.SplomLib
         public decimal? SizeRef { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  size .
+        ///     Sets the source reference on Chart Studio Cloud for <c>size</c>.
         /// </summary>
         [JsonPropertyName(@"sizesrc")]
         public string SizeSrc { get; set;} 
@@ -221,7 +221,7 @@ namespace Plotly.Blazor.Traces.SplomLib
         public IList<Plotly.Blazor.Traces.SplomLib.MarkerLib.SymbolEnum?> SymbolArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  symbol .
+        ///     Sets the source reference on Chart Studio Cloud for <c>symbol</c>.
         /// </summary>
         [JsonPropertyName(@"symbolsrc")]
         public string SymbolSrc { get; set;} 

--- a/Plotly.Blazor/Traces/SplomLib/MarkerLib/Line.cs
+++ b/Plotly.Blazor/Traces/SplomLib/MarkerLib/Line.cs
@@ -110,7 +110,7 @@ namespace Plotly.Blazor.Traces.SplomLib.MarkerLib
         public object ColorScale { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  color .
+        ///     Sets the source reference on Chart Studio Cloud for <c>color</c>.
         /// </summary>
         [JsonPropertyName(@"colorsrc")]
         public string ColorSrc { get; set;} 
@@ -138,7 +138,7 @@ namespace Plotly.Blazor.Traces.SplomLib.MarkerLib
         public IList<decimal?> WidthArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  width .
+        ///     Sets the source reference on Chart Studio Cloud for <c>width</c>.
         /// </summary>
         [JsonPropertyName(@"widthsrc")]
         public string WidthSrc { get; set;} 

--- a/Plotly.Blazor/Traces/StreamTube.cs
+++ b/Plotly.Blazor/Traces/StreamTube.cs
@@ -103,7 +103,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> CustomData { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  customdata .
+        ///     Sets the source reference on Chart Studio Cloud for <c>customdata</c>.
         /// </summary>
         [JsonPropertyName(@"customdatasrc")]
         public string CustomDataSrc { get; set;} 
@@ -126,7 +126,7 @@ namespace Plotly.Blazor.Traces
         public IList<Plotly.Blazor.Traces.StreamTubeLib.HoverInfoFlag?> HoverInfoArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  hoverinfo .
+        ///     Sets the source reference on Chart Studio Cloud for <c>hoverinfo</c>.
         /// </summary>
         [JsonPropertyName(@"hoverinfosrc")]
         public string HoverInfoSrc { get; set;} 
@@ -189,7 +189,7 @@ namespace Plotly.Blazor.Traces
         public IList<string> HoverTemplateArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  hovertemplate .
+        ///     Sets the source reference on Chart Studio Cloud for <c>hovertemplate</c>.
         /// </summary>
         [JsonPropertyName(@"hovertemplatesrc")]
         public string HoverTemplateSrc { get; set;} 
@@ -209,7 +209,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> Ids { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  ids .
+        ///     Sets the source reference on Chart Studio Cloud for <c>ids</c>.
         /// </summary>
         [JsonPropertyName(@"idssrc")]
         public string IdsSrc { get; set;} 
@@ -285,7 +285,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> MetaArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  meta .
+        ///     Sets the source reference on Chart Studio Cloud for <c>meta</c>.
         /// </summary>
         [JsonPropertyName(@"metasrc")]
         public string MetaSrc { get; set;} 
@@ -402,7 +402,7 @@ namespace Plotly.Blazor.Traces
         public object UiRevision { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  u .
+        ///     Sets the source reference on Chart Studio Cloud for <c>u</c>.
         /// </summary>
         [JsonPropertyName(@"usrc")]
         public string USrc { get; set;} 
@@ -430,7 +430,7 @@ namespace Plotly.Blazor.Traces
         public Plotly.Blazor.Traces.StreamTubeLib.VisibleEnum? Visible { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  v .
+        ///     Sets the source reference on Chart Studio Cloud for <c>v</c>.
         /// </summary>
         [JsonPropertyName(@"vsrc")]
         public string VSrc { get; set;} 
@@ -450,7 +450,7 @@ namespace Plotly.Blazor.Traces
         public string WHoverFormat { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  w .
+        ///     Sets the source reference on Chart Studio Cloud for <c>w</c>.
         /// </summary>
         [JsonPropertyName(@"wsrc")]
         public string WSrc { get; set;} 
@@ -475,7 +475,7 @@ namespace Plotly.Blazor.Traces
         public string XHoverFormat { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  x .
+        ///     Sets the source reference on Chart Studio Cloud for <c>x</c>.
         /// </summary>
         [JsonPropertyName(@"xsrc")]
         public string XSrc { get; set;} 
@@ -500,7 +500,7 @@ namespace Plotly.Blazor.Traces
         public string YHoverFormat { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  y .
+        ///     Sets the source reference on Chart Studio Cloud for <c>y</c>.
         /// </summary>
         [JsonPropertyName(@"ysrc")]
         public string YSrc { get; set;} 
@@ -525,7 +525,7 @@ namespace Plotly.Blazor.Traces
         public string ZHoverFormat { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  z .
+        ///     Sets the source reference on Chart Studio Cloud for <c>z</c>.
         /// </summary>
         [JsonPropertyName(@"zsrc")]
         public string ZSrc { get; set;} 

--- a/Plotly.Blazor/Traces/StreamTubeLib/HoverLabel.cs
+++ b/Plotly.Blazor/Traces/StreamTubeLib/HoverLabel.cs
@@ -36,7 +36,7 @@ namespace Plotly.Blazor.Traces.StreamTubeLib
         public IList<Plotly.Blazor.Traces.StreamTubeLib.HoverLabelLib.AlignEnum?> AlignArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  align .
+        ///     Sets the source reference on Chart Studio Cloud for <c>align</c>.
         /// </summary>
         [JsonPropertyName(@"alignsrc")]
         public string AlignSrc { get; set;} 
@@ -55,7 +55,7 @@ namespace Plotly.Blazor.Traces.StreamTubeLib
         public IList<object> BgColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  bgcolor .
+        ///     Sets the source reference on Chart Studio Cloud for <c>bgcolor</c>.
         /// </summary>
         [JsonPropertyName(@"bgcolorsrc")]
         public string BgColorSrc { get; set;} 
@@ -74,7 +74,7 @@ namespace Plotly.Blazor.Traces.StreamTubeLib
         public IList<object> BorderColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  bordercolor .
+        ///     Sets the source reference on Chart Studio Cloud for <c>bordercolor</c>.
         /// </summary>
         [JsonPropertyName(@"bordercolorsrc")]
         public string BorderColorSrc { get; set;} 
@@ -107,7 +107,7 @@ namespace Plotly.Blazor.Traces.StreamTubeLib
         public IList<int?> NameLengthArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  namelength .
+        ///     Sets the source reference on Chart Studio Cloud for <c>namelength</c>.
         /// </summary>
         [JsonPropertyName(@"namelengthsrc")]
         public string NameLengthSrc { get; set;} 

--- a/Plotly.Blazor/Traces/StreamTubeLib/HoverLabelLib/Font.cs
+++ b/Plotly.Blazor/Traces/StreamTubeLib/HoverLabelLib/Font.cs
@@ -34,7 +34,7 @@ namespace Plotly.Blazor.Traces.StreamTubeLib.HoverLabelLib
         public IList<object> ColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  color .
+        ///     Sets the source reference on Chart Studio Cloud for <c>color</c>.
         /// </summary>
         [JsonPropertyName(@"colorsrc")]
         public string ColorSrc { get; set;} 
@@ -73,7 +73,7 @@ namespace Plotly.Blazor.Traces.StreamTubeLib.HoverLabelLib
         public IList<string> FamilyArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  family .
+        ///     Sets the source reference on Chart Studio Cloud for <c>family</c>.
         /// </summary>
         [JsonPropertyName(@"familysrc")]
         public string FamilySrc { get; set;} 
@@ -92,7 +92,7 @@ namespace Plotly.Blazor.Traces.StreamTubeLib.HoverLabelLib
         public IList<decimal?> SizeArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  size .
+        ///     Sets the source reference on Chart Studio Cloud for <c>size</c>.
         /// </summary>
         [JsonPropertyName(@"sizesrc")]
         public string SizeSrc { get; set;} 

--- a/Plotly.Blazor/Traces/StreamTubeLib/Starts.cs
+++ b/Plotly.Blazor/Traces/StreamTubeLib/Starts.cs
@@ -26,7 +26,7 @@ namespace Plotly.Blazor.Traces.StreamTubeLib
         public IList<object> X { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  x .
+        ///     Sets the source reference on Chart Studio Cloud for <c>x</c>.
         /// </summary>
         [JsonPropertyName(@"xsrc")]
         public string XSrc { get; set;} 
@@ -38,7 +38,7 @@ namespace Plotly.Blazor.Traces.StreamTubeLib
         public IList<object> Y { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  y .
+        ///     Sets the source reference on Chart Studio Cloud for <c>y</c>.
         /// </summary>
         [JsonPropertyName(@"ysrc")]
         public string YSrc { get; set;} 
@@ -50,7 +50,7 @@ namespace Plotly.Blazor.Traces.StreamTubeLib
         public IList<object> Z { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  z .
+        ///     Sets the source reference on Chart Studio Cloud for <c>z</c>.
         /// </summary>
         [JsonPropertyName(@"zsrc")]
         public string ZSrc { get; set;} 

--- a/Plotly.Blazor/Traces/Sunburst.cs
+++ b/Plotly.Blazor/Traces/Sunburst.cs
@@ -51,7 +51,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> CustomData { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  customdata .
+        ///     Sets the source reference on Chart Studio Cloud for <c>customdata</c>.
         /// </summary>
         [JsonPropertyName(@"customdatasrc")]
         public string CustomDataSrc { get; set;} 
@@ -80,7 +80,7 @@ namespace Plotly.Blazor.Traces
         public IList<Plotly.Blazor.Traces.SunburstLib.HoverInfoFlag?> HoverInfoArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  hoverinfo .
+        ///     Sets the source reference on Chart Studio Cloud for <c>hoverinfo</c>.
         /// </summary>
         [JsonPropertyName(@"hoverinfosrc")]
         public string HoverInfoSrc { get; set;} 
@@ -143,7 +143,7 @@ namespace Plotly.Blazor.Traces
         public IList<string> HoverTemplateArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  hovertemplate .
+        ///     Sets the source reference on Chart Studio Cloud for <c>hovertemplate</c>.
         /// </summary>
         [JsonPropertyName(@"hovertemplatesrc")]
         public string HoverTemplateSrc { get; set;} 
@@ -168,7 +168,7 @@ namespace Plotly.Blazor.Traces
         public IList<string> HoverTextArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  hovertext .
+        ///     Sets the source reference on Chart Studio Cloud for <c>hovertext</c>.
         /// </summary>
         [JsonPropertyName(@"hovertextsrc")]
         public string HoverTextSrc { get; set;} 
@@ -182,7 +182,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> Ids { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  ids .
+        ///     Sets the source reference on Chart Studio Cloud for <c>ids</c>.
         /// </summary>
         [JsonPropertyName(@"idssrc")]
         public string IdsSrc { get; set;} 
@@ -212,7 +212,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> Labels { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  labels .
+        ///     Sets the source reference on Chart Studio Cloud for <c>labels</c>.
         /// </summary>
         [JsonPropertyName(@"labelssrc")]
         public string LabelsSrc { get; set;} 
@@ -291,7 +291,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> MetaArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  meta .
+        ///     Sets the source reference on Chart Studio Cloud for <c>meta</c>.
         /// </summary>
         [JsonPropertyName(@"metasrc")]
         public string MetaSrc { get; set;} 
@@ -328,7 +328,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> Parents { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  parents .
+        ///     Sets the source reference on Chart Studio Cloud for <c>parents</c>.
         /// </summary>
         [JsonPropertyName(@"parentssrc")]
         public string ParentsSrc { get; set;} 
@@ -380,7 +380,7 @@ namespace Plotly.Blazor.Traces
         public Plotly.Blazor.Traces.SunburstLib.TextInfoFlag? TextInfo { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  text .
+        ///     Sets the source reference on Chart Studio Cloud for <c>text</c>.
         /// </summary>
         [JsonPropertyName(@"textsrc")]
         public string TextSrc { get; set;} 
@@ -421,7 +421,7 @@ namespace Plotly.Blazor.Traces
         public IList<string> TextTemplateArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  texttemplate .
+        ///     Sets the source reference on Chart Studio Cloud for <c>texttemplate</c>.
         /// </summary>
         [JsonPropertyName(@"texttemplatesrc")]
         public string TextTemplateSrc { get; set;} 
@@ -464,7 +464,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> Values { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  values .
+        ///     Sets the source reference on Chart Studio Cloud for <c>values</c>.
         /// </summary>
         [JsonPropertyName(@"valuessrc")]
         public string ValuesSrc { get; set;} 

--- a/Plotly.Blazor/Traces/SunburstLib/HoverLabel.cs
+++ b/Plotly.Blazor/Traces/SunburstLib/HoverLabel.cs
@@ -36,7 +36,7 @@ namespace Plotly.Blazor.Traces.SunburstLib
         public IList<Plotly.Blazor.Traces.SunburstLib.HoverLabelLib.AlignEnum?> AlignArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  align .
+        ///     Sets the source reference on Chart Studio Cloud for <c>align</c>.
         /// </summary>
         [JsonPropertyName(@"alignsrc")]
         public string AlignSrc { get; set;} 
@@ -55,7 +55,7 @@ namespace Plotly.Blazor.Traces.SunburstLib
         public IList<object> BgColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  bgcolor .
+        ///     Sets the source reference on Chart Studio Cloud for <c>bgcolor</c>.
         /// </summary>
         [JsonPropertyName(@"bgcolorsrc")]
         public string BgColorSrc { get; set;} 
@@ -74,7 +74,7 @@ namespace Plotly.Blazor.Traces.SunburstLib
         public IList<object> BorderColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  bordercolor .
+        ///     Sets the source reference on Chart Studio Cloud for <c>bordercolor</c>.
         /// </summary>
         [JsonPropertyName(@"bordercolorsrc")]
         public string BorderColorSrc { get; set;} 
@@ -107,7 +107,7 @@ namespace Plotly.Blazor.Traces.SunburstLib
         public IList<int?> NameLengthArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  namelength .
+        ///     Sets the source reference on Chart Studio Cloud for <c>namelength</c>.
         /// </summary>
         [JsonPropertyName(@"namelengthsrc")]
         public string NameLengthSrc { get; set;} 

--- a/Plotly.Blazor/Traces/SunburstLib/InsideTextFont.cs
+++ b/Plotly.Blazor/Traces/SunburstLib/InsideTextFont.cs
@@ -34,7 +34,7 @@ namespace Plotly.Blazor.Traces.SunburstLib
         public IList<object> ColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  color .
+        ///     Sets the source reference on Chart Studio Cloud for <c>color</c>.
         /// </summary>
         [JsonPropertyName(@"colorsrc")]
         public string ColorSrc { get; set;} 
@@ -73,7 +73,7 @@ namespace Plotly.Blazor.Traces.SunburstLib
         public IList<string> FamilyArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  family .
+        ///     Sets the source reference on Chart Studio Cloud for <c>family</c>.
         /// </summary>
         [JsonPropertyName(@"familysrc")]
         public string FamilySrc { get; set;} 
@@ -92,7 +92,7 @@ namespace Plotly.Blazor.Traces.SunburstLib
         public IList<decimal?> SizeArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  size .
+        ///     Sets the source reference on Chart Studio Cloud for <c>size</c>.
         /// </summary>
         [JsonPropertyName(@"sizesrc")]
         public string SizeSrc { get; set;} 

--- a/Plotly.Blazor/Traces/SunburstLib/Marker.cs
+++ b/Plotly.Blazor/Traces/SunburstLib/Marker.cs
@@ -101,7 +101,7 @@ namespace Plotly.Blazor.Traces.SunburstLib
         public object ColorScale { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  colors .
+        ///     Sets the source reference on Chart Studio Cloud for <c>colors</c>.
         /// </summary>
         [JsonPropertyName(@"colorssrc")]
         public string ColorsSrc { get; set;} 

--- a/Plotly.Blazor/Traces/SunburstLib/MarkerLib/Line.cs
+++ b/Plotly.Blazor/Traces/SunburstLib/MarkerLib/Line.cs
@@ -36,7 +36,7 @@ namespace Plotly.Blazor.Traces.SunburstLib.MarkerLib
         public IList<object> ColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  color .
+        ///     Sets the source reference on Chart Studio Cloud for <c>color</c>.
         /// </summary>
         [JsonPropertyName(@"colorsrc")]
         public string ColorSrc { get; set;} 
@@ -55,7 +55,7 @@ namespace Plotly.Blazor.Traces.SunburstLib.MarkerLib
         public IList<decimal?> WidthArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  width .
+        ///     Sets the source reference on Chart Studio Cloud for <c>width</c>.
         /// </summary>
         [JsonPropertyName(@"widthsrc")]
         public string WidthSrc { get; set;} 

--- a/Plotly.Blazor/Traces/SunburstLib/OutsideTextFont.cs
+++ b/Plotly.Blazor/Traces/SunburstLib/OutsideTextFont.cs
@@ -34,7 +34,7 @@ namespace Plotly.Blazor.Traces.SunburstLib
         public IList<object> ColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  color .
+        ///     Sets the source reference on Chart Studio Cloud for <c>color</c>.
         /// </summary>
         [JsonPropertyName(@"colorsrc")]
         public string ColorSrc { get; set;} 
@@ -73,7 +73,7 @@ namespace Plotly.Blazor.Traces.SunburstLib
         public IList<string> FamilyArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  family .
+        ///     Sets the source reference on Chart Studio Cloud for <c>family</c>.
         /// </summary>
         [JsonPropertyName(@"familysrc")]
         public string FamilySrc { get; set;} 
@@ -92,7 +92,7 @@ namespace Plotly.Blazor.Traces.SunburstLib
         public IList<decimal?> SizeArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  size .
+        ///     Sets the source reference on Chart Studio Cloud for <c>size</c>.
         /// </summary>
         [JsonPropertyName(@"sizesrc")]
         public string SizeSrc { get; set;} 

--- a/Plotly.Blazor/Traces/SunburstLib/TextFont.cs
+++ b/Plotly.Blazor/Traces/SunburstLib/TextFont.cs
@@ -34,7 +34,7 @@ namespace Plotly.Blazor.Traces.SunburstLib
         public IList<object> ColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  color .
+        ///     Sets the source reference on Chart Studio Cloud for <c>color</c>.
         /// </summary>
         [JsonPropertyName(@"colorsrc")]
         public string ColorSrc { get; set;} 
@@ -73,7 +73,7 @@ namespace Plotly.Blazor.Traces.SunburstLib
         public IList<string> FamilyArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  family .
+        ///     Sets the source reference on Chart Studio Cloud for <c>family</c>.
         /// </summary>
         [JsonPropertyName(@"familysrc")]
         public string FamilySrc { get; set;} 
@@ -92,7 +92,7 @@ namespace Plotly.Blazor.Traces.SunburstLib
         public IList<decimal?> SizeArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  size .
+        ///     Sets the source reference on Chart Studio Cloud for <c>size</c>.
         /// </summary>
         [JsonPropertyName(@"sizesrc")]
         public string SizeSrc { get; set;} 

--- a/Plotly.Blazor/Traces/Surface.cs
+++ b/Plotly.Blazor/Traces/Surface.cs
@@ -116,7 +116,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> CustomData { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  customdata .
+        ///     Sets the source reference on Chart Studio Cloud for <c>customdata</c>.
         /// </summary>
         [JsonPropertyName(@"customdatasrc")]
         public string CustomDataSrc { get; set;} 
@@ -147,7 +147,7 @@ namespace Plotly.Blazor.Traces
         public IList<Plotly.Blazor.Traces.SurfaceLib.HoverInfoFlag?> HoverInfoArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  hoverinfo .
+        ///     Sets the source reference on Chart Studio Cloud for <c>hoverinfo</c>.
         /// </summary>
         [JsonPropertyName(@"hoverinfosrc")]
         public string HoverInfoSrc { get; set;} 
@@ -208,7 +208,7 @@ namespace Plotly.Blazor.Traces
         public IList<string> HoverTemplateArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  hovertemplate .
+        ///     Sets the source reference on Chart Studio Cloud for <c>hovertemplate</c>.
         /// </summary>
         [JsonPropertyName(@"hovertemplatesrc")]
         public string HoverTemplateSrc { get; set;} 
@@ -227,7 +227,7 @@ namespace Plotly.Blazor.Traces
         public IList<string> HoverTextArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  hovertext .
+        ///     Sets the source reference on Chart Studio Cloud for <c>hovertext</c>.
         /// </summary>
         [JsonPropertyName(@"hovertextsrc")]
         public string HoverTextSrc { get; set;} 
@@ -241,7 +241,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> Ids { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  ids .
+        ///     Sets the source reference on Chart Studio Cloud for <c>ids</c>.
         /// </summary>
         [JsonPropertyName(@"idssrc")]
         public string IdsSrc { get; set;} 
@@ -311,7 +311,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> MetaArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  meta .
+        ///     Sets the source reference on Chart Studio Cloud for <c>meta</c>.
         /// </summary>
         [JsonPropertyName(@"metasrc")]
         public string MetaSrc { get; set;} 
@@ -389,7 +389,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> SurfaceColor { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  surfacecolor .
+        ///     Sets the source reference on Chart Studio Cloud for <c>surfacecolor</c>.
         /// </summary>
         [JsonPropertyName(@"surfacecolorsrc")]
         public string SurfaceColorSrc { get; set;} 
@@ -412,7 +412,7 @@ namespace Plotly.Blazor.Traces
         public IList<string> TextArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  text .
+        ///     Sets the source reference on Chart Studio Cloud for <c>text</c>.
         /// </summary>
         [JsonPropertyName(@"textsrc")]
         public string TextSrc { get; set;} 
@@ -475,7 +475,7 @@ namespace Plotly.Blazor.Traces
         public string XHoverFormat { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  x .
+        ///     Sets the source reference on Chart Studio Cloud for <c>x</c>.
         /// </summary>
         [JsonPropertyName(@"xsrc")]
         public string XSrc { get; set;} 
@@ -506,7 +506,7 @@ namespace Plotly.Blazor.Traces
         public string YHoverFormat { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  y .
+        ///     Sets the source reference on Chart Studio Cloud for <c>y</c>.
         /// </summary>
         [JsonPropertyName(@"ysrc")]
         public string YSrc { get; set;} 
@@ -537,7 +537,7 @@ namespace Plotly.Blazor.Traces
         public string ZHoverFormat { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  z .
+        ///     Sets the source reference on Chart Studio Cloud for <c>z</c>.
         /// </summary>
         [JsonPropertyName(@"zsrc")]
         public string ZSrc { get; set;} 

--- a/Plotly.Blazor/Traces/SurfaceLib/HoverLabel.cs
+++ b/Plotly.Blazor/Traces/SurfaceLib/HoverLabel.cs
@@ -36,7 +36,7 @@ namespace Plotly.Blazor.Traces.SurfaceLib
         public IList<Plotly.Blazor.Traces.SurfaceLib.HoverLabelLib.AlignEnum?> AlignArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  align .
+        ///     Sets the source reference on Chart Studio Cloud for <c>align</c>.
         /// </summary>
         [JsonPropertyName(@"alignsrc")]
         public string AlignSrc { get; set;} 
@@ -55,7 +55,7 @@ namespace Plotly.Blazor.Traces.SurfaceLib
         public IList<object> BgColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  bgcolor .
+        ///     Sets the source reference on Chart Studio Cloud for <c>bgcolor</c>.
         /// </summary>
         [JsonPropertyName(@"bgcolorsrc")]
         public string BgColorSrc { get; set;} 
@@ -74,7 +74,7 @@ namespace Plotly.Blazor.Traces.SurfaceLib
         public IList<object> BorderColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  bordercolor .
+        ///     Sets the source reference on Chart Studio Cloud for <c>bordercolor</c>.
         /// </summary>
         [JsonPropertyName(@"bordercolorsrc")]
         public string BorderColorSrc { get; set;} 
@@ -107,7 +107,7 @@ namespace Plotly.Blazor.Traces.SurfaceLib
         public IList<int?> NameLengthArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  namelength .
+        ///     Sets the source reference on Chart Studio Cloud for <c>namelength</c>.
         /// </summary>
         [JsonPropertyName(@"namelengthsrc")]
         public string NameLengthSrc { get; set;} 

--- a/Plotly.Blazor/Traces/SurfaceLib/HoverLabelLib/Font.cs
+++ b/Plotly.Blazor/Traces/SurfaceLib/HoverLabelLib/Font.cs
@@ -34,7 +34,7 @@ namespace Plotly.Blazor.Traces.SurfaceLib.HoverLabelLib
         public IList<object> ColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  color .
+        ///     Sets the source reference on Chart Studio Cloud for <c>color</c>.
         /// </summary>
         [JsonPropertyName(@"colorsrc")]
         public string ColorSrc { get; set;} 
@@ -73,7 +73,7 @@ namespace Plotly.Blazor.Traces.SurfaceLib.HoverLabelLib
         public IList<string> FamilyArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  family .
+        ///     Sets the source reference on Chart Studio Cloud for <c>family</c>.
         /// </summary>
         [JsonPropertyName(@"familysrc")]
         public string FamilySrc { get; set;} 
@@ -92,7 +92,7 @@ namespace Plotly.Blazor.Traces.SurfaceLib.HoverLabelLib
         public IList<decimal?> SizeArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  size .
+        ///     Sets the source reference on Chart Studio Cloud for <c>size</c>.
         /// </summary>
         [JsonPropertyName(@"sizesrc")]
         public string SizeSrc { get; set;} 

--- a/Plotly.Blazor/Traces/Table.cs
+++ b/Plotly.Blazor/Traces/Table.cs
@@ -40,7 +40,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> ColumnOrder { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  columnorder .
+        ///     Sets the source reference on Chart Studio Cloud for <c>columnorder</c>.
         /// </summary>
         [JsonPropertyName(@"columnordersrc")]
         public string ColumnOrderSrc { get; set;} 
@@ -61,7 +61,7 @@ namespace Plotly.Blazor.Traces
         public IList<decimal?> ColumnWidthArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  columnwidth .
+        ///     Sets the source reference on Chart Studio Cloud for <c>columnwidth</c>.
         /// </summary>
         [JsonPropertyName(@"columnwidthsrc")]
         public string ColumnWidthSrc { get; set;} 
@@ -75,7 +75,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> CustomData { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  customdata .
+        ///     Sets the source reference on Chart Studio Cloud for <c>customdata</c>.
         /// </summary>
         [JsonPropertyName(@"customdatasrc")]
         public string CustomDataSrc { get; set;} 
@@ -110,7 +110,7 @@ namespace Plotly.Blazor.Traces
         public IList<Plotly.Blazor.Traces.TableLib.HoverInfoFlag?> HoverInfoArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  hoverinfo .
+        ///     Sets the source reference on Chart Studio Cloud for <c>hoverinfo</c>.
         /// </summary>
         [JsonPropertyName(@"hoverinfosrc")]
         public string HoverInfoSrc { get; set;} 
@@ -130,7 +130,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> Ids { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  ids .
+        ///     Sets the source reference on Chart Studio Cloud for <c>ids</c>.
         /// </summary>
         [JsonPropertyName(@"idssrc")]
         public string IdsSrc { get; set;} 
@@ -181,7 +181,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> MetaArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  meta .
+        ///     Sets the source reference on Chart Studio Cloud for <c>meta</c>.
         /// </summary>
         [JsonPropertyName(@"metasrc")]
         public string MetaSrc { get; set;} 

--- a/Plotly.Blazor/Traces/TableLib/Cells.cs
+++ b/Plotly.Blazor/Traces/TableLib/Cells.cs
@@ -40,7 +40,7 @@ namespace Plotly.Blazor.Traces.TableLib
         public IList<Plotly.Blazor.Traces.TableLib.CellsLib.AlignEnum?> AlignArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  align .
+        ///     Sets the source reference on Chart Studio Cloud for <c>align</c>.
         /// </summary>
         [JsonPropertyName(@"alignsrc")]
         public string AlignSrc { get; set;} 
@@ -65,7 +65,7 @@ namespace Plotly.Blazor.Traces.TableLib
         public IList<object> Format { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  format .
+        ///     Sets the source reference on Chart Studio Cloud for <c>format</c>.
         /// </summary>
         [JsonPropertyName(@"formatsrc")]
         public string FormatSrc { get; set;} 
@@ -96,7 +96,7 @@ namespace Plotly.Blazor.Traces.TableLib
         public IList<string> PrefixArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  prefix .
+        ///     Sets the source reference on Chart Studio Cloud for <c>prefix</c>.
         /// </summary>
         [JsonPropertyName(@"prefixsrc")]
         public string PrefixSrc { get; set;} 
@@ -115,7 +115,7 @@ namespace Plotly.Blazor.Traces.TableLib
         public IList<string> SuffixArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  suffix .
+        ///     Sets the source reference on Chart Studio Cloud for <c>suffix</c>.
         /// </summary>
         [JsonPropertyName(@"suffixsrc")]
         public string SuffixSrc { get; set;} 
@@ -130,7 +130,7 @@ namespace Plotly.Blazor.Traces.TableLib
         public IList<object> Values { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  values .
+        ///     Sets the source reference on Chart Studio Cloud for <c>values</c>.
         /// </summary>
         [JsonPropertyName(@"valuessrc")]
         public string ValuesSrc { get; set;} 

--- a/Plotly.Blazor/Traces/TableLib/CellsLib/Fill.cs
+++ b/Plotly.Blazor/Traces/TableLib/CellsLib/Fill.cs
@@ -36,7 +36,7 @@ namespace Plotly.Blazor.Traces.TableLib.CellsLib
         public IList<object> ColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  color .
+        ///     Sets the source reference on Chart Studio Cloud for <c>color</c>.
         /// </summary>
         [JsonPropertyName(@"colorsrc")]
         public string ColorSrc { get; set;} 

--- a/Plotly.Blazor/Traces/TableLib/CellsLib/Font.cs
+++ b/Plotly.Blazor/Traces/TableLib/CellsLib/Font.cs
@@ -34,7 +34,7 @@ namespace Plotly.Blazor.Traces.TableLib.CellsLib
         public IList<object> ColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  color .
+        ///     Sets the source reference on Chart Studio Cloud for <c>color</c>.
         /// </summary>
         [JsonPropertyName(@"colorsrc")]
         public string ColorSrc { get; set;} 
@@ -73,7 +73,7 @@ namespace Plotly.Blazor.Traces.TableLib.CellsLib
         public IList<string> FamilyArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  family .
+        ///     Sets the source reference on Chart Studio Cloud for <c>family</c>.
         /// </summary>
         [JsonPropertyName(@"familysrc")]
         public string FamilySrc { get; set;} 
@@ -92,7 +92,7 @@ namespace Plotly.Blazor.Traces.TableLib.CellsLib
         public IList<decimal?> SizeArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  size .
+        ///     Sets the source reference on Chart Studio Cloud for <c>size</c>.
         /// </summary>
         [JsonPropertyName(@"sizesrc")]
         public string SizeSrc { get; set;} 

--- a/Plotly.Blazor/Traces/TableLib/CellsLib/Line.cs
+++ b/Plotly.Blazor/Traces/TableLib/CellsLib/Line.cs
@@ -34,7 +34,7 @@ namespace Plotly.Blazor.Traces.TableLib.CellsLib
         public IList<object> ColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  color .
+        ///     Sets the source reference on Chart Studio Cloud for <c>color</c>.
         /// </summary>
         [JsonPropertyName(@"colorsrc")]
         public string ColorSrc { get; set;} 
@@ -53,7 +53,7 @@ namespace Plotly.Blazor.Traces.TableLib.CellsLib
         public IList<decimal?> WidthArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  width .
+        ///     Sets the source reference on Chart Studio Cloud for <c>width</c>.
         /// </summary>
         [JsonPropertyName(@"widthsrc")]
         public string WidthSrc { get; set;} 

--- a/Plotly.Blazor/Traces/TableLib/Header.cs
+++ b/Plotly.Blazor/Traces/TableLib/Header.cs
@@ -40,7 +40,7 @@ namespace Plotly.Blazor.Traces.TableLib
         public IList<Plotly.Blazor.Traces.TableLib.HeaderLib.AlignEnum?> AlignArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  align .
+        ///     Sets the source reference on Chart Studio Cloud for <c>align</c>.
         /// </summary>
         [JsonPropertyName(@"alignsrc")]
         public string AlignSrc { get; set;} 
@@ -65,7 +65,7 @@ namespace Plotly.Blazor.Traces.TableLib
         public IList<object> Format { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  format .
+        ///     Sets the source reference on Chart Studio Cloud for <c>format</c>.
         /// </summary>
         [JsonPropertyName(@"formatsrc")]
         public string FormatSrc { get; set;} 
@@ -96,7 +96,7 @@ namespace Plotly.Blazor.Traces.TableLib
         public IList<string> PrefixArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  prefix .
+        ///     Sets the source reference on Chart Studio Cloud for <c>prefix</c>.
         /// </summary>
         [JsonPropertyName(@"prefixsrc")]
         public string PrefixSrc { get; set;} 
@@ -115,7 +115,7 @@ namespace Plotly.Blazor.Traces.TableLib
         public IList<string> SuffixArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  suffix .
+        ///     Sets the source reference on Chart Studio Cloud for <c>suffix</c>.
         /// </summary>
         [JsonPropertyName(@"suffixsrc")]
         public string SuffixSrc { get; set;} 
@@ -130,7 +130,7 @@ namespace Plotly.Blazor.Traces.TableLib
         public IList<object> Values { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  values .
+        ///     Sets the source reference on Chart Studio Cloud for <c>values</c>.
         /// </summary>
         [JsonPropertyName(@"valuessrc")]
         public string ValuesSrc { get; set;} 

--- a/Plotly.Blazor/Traces/TableLib/HeaderLib/Fill.cs
+++ b/Plotly.Blazor/Traces/TableLib/HeaderLib/Fill.cs
@@ -36,7 +36,7 @@ namespace Plotly.Blazor.Traces.TableLib.HeaderLib
         public IList<object> ColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  color .
+        ///     Sets the source reference on Chart Studio Cloud for <c>color</c>.
         /// </summary>
         [JsonPropertyName(@"colorsrc")]
         public string ColorSrc { get; set;} 

--- a/Plotly.Blazor/Traces/TableLib/HeaderLib/Font.cs
+++ b/Plotly.Blazor/Traces/TableLib/HeaderLib/Font.cs
@@ -34,7 +34,7 @@ namespace Plotly.Blazor.Traces.TableLib.HeaderLib
         public IList<object> ColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  color .
+        ///     Sets the source reference on Chart Studio Cloud for <c>color</c>.
         /// </summary>
         [JsonPropertyName(@"colorsrc")]
         public string ColorSrc { get; set;} 
@@ -73,7 +73,7 @@ namespace Plotly.Blazor.Traces.TableLib.HeaderLib
         public IList<string> FamilyArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  family .
+        ///     Sets the source reference on Chart Studio Cloud for <c>family</c>.
         /// </summary>
         [JsonPropertyName(@"familysrc")]
         public string FamilySrc { get; set;} 
@@ -92,7 +92,7 @@ namespace Plotly.Blazor.Traces.TableLib.HeaderLib
         public IList<decimal?> SizeArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  size .
+        ///     Sets the source reference on Chart Studio Cloud for <c>size</c>.
         /// </summary>
         [JsonPropertyName(@"sizesrc")]
         public string SizeSrc { get; set;} 

--- a/Plotly.Blazor/Traces/TableLib/HeaderLib/Line.cs
+++ b/Plotly.Blazor/Traces/TableLib/HeaderLib/Line.cs
@@ -34,7 +34,7 @@ namespace Plotly.Blazor.Traces.TableLib.HeaderLib
         public IList<object> ColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  color .
+        ///     Sets the source reference on Chart Studio Cloud for <c>color</c>.
         /// </summary>
         [JsonPropertyName(@"colorsrc")]
         public string ColorSrc { get; set;} 
@@ -53,7 +53,7 @@ namespace Plotly.Blazor.Traces.TableLib.HeaderLib
         public IList<decimal?> WidthArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  width .
+        ///     Sets the source reference on Chart Studio Cloud for <c>width</c>.
         /// </summary>
         [JsonPropertyName(@"widthsrc")]
         public string WidthSrc { get; set;} 

--- a/Plotly.Blazor/Traces/TableLib/HoverLabel.cs
+++ b/Plotly.Blazor/Traces/TableLib/HoverLabel.cs
@@ -36,7 +36,7 @@ namespace Plotly.Blazor.Traces.TableLib
         public IList<Plotly.Blazor.Traces.TableLib.HoverLabelLib.AlignEnum?> AlignArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  align .
+        ///     Sets the source reference on Chart Studio Cloud for <c>align</c>.
         /// </summary>
         [JsonPropertyName(@"alignsrc")]
         public string AlignSrc { get; set;} 
@@ -55,7 +55,7 @@ namespace Plotly.Blazor.Traces.TableLib
         public IList<object> BgColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  bgcolor .
+        ///     Sets the source reference on Chart Studio Cloud for <c>bgcolor</c>.
         /// </summary>
         [JsonPropertyName(@"bgcolorsrc")]
         public string BgColorSrc { get; set;} 
@@ -74,7 +74,7 @@ namespace Plotly.Blazor.Traces.TableLib
         public IList<object> BorderColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  bordercolor .
+        ///     Sets the source reference on Chart Studio Cloud for <c>bordercolor</c>.
         /// </summary>
         [JsonPropertyName(@"bordercolorsrc")]
         public string BorderColorSrc { get; set;} 
@@ -107,7 +107,7 @@ namespace Plotly.Blazor.Traces.TableLib
         public IList<int?> NameLengthArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  namelength .
+        ///     Sets the source reference on Chart Studio Cloud for <c>namelength</c>.
         /// </summary>
         [JsonPropertyName(@"namelengthsrc")]
         public string NameLengthSrc { get; set;} 

--- a/Plotly.Blazor/Traces/TableLib/HoverLabelLib/Font.cs
+++ b/Plotly.Blazor/Traces/TableLib/HoverLabelLib/Font.cs
@@ -34,7 +34,7 @@ namespace Plotly.Blazor.Traces.TableLib.HoverLabelLib
         public IList<object> ColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  color .
+        ///     Sets the source reference on Chart Studio Cloud for <c>color</c>.
         /// </summary>
         [JsonPropertyName(@"colorsrc")]
         public string ColorSrc { get; set;} 
@@ -73,7 +73,7 @@ namespace Plotly.Blazor.Traces.TableLib.HoverLabelLib
         public IList<string> FamilyArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  family .
+        ///     Sets the source reference on Chart Studio Cloud for <c>family</c>.
         /// </summary>
         [JsonPropertyName(@"familysrc")]
         public string FamilySrc { get; set;} 
@@ -92,7 +92,7 @@ namespace Plotly.Blazor.Traces.TableLib.HoverLabelLib
         public IList<decimal?> SizeArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  size .
+        ///     Sets the source reference on Chart Studio Cloud for <c>size</c>.
         /// </summary>
         [JsonPropertyName(@"sizesrc")]
         public string SizeSrc { get; set;} 

--- a/Plotly.Blazor/Traces/TreeMap.cs
+++ b/Plotly.Blazor/Traces/TreeMap.cs
@@ -51,7 +51,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> CustomData { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  customdata .
+        ///     Sets the source reference on Chart Studio Cloud for <c>customdata</c>.
         /// </summary>
         [JsonPropertyName(@"customdatasrc")]
         public string CustomDataSrc { get; set;} 
@@ -80,7 +80,7 @@ namespace Plotly.Blazor.Traces
         public IList<Plotly.Blazor.Traces.TreeMapLib.HoverInfoFlag?> HoverInfoArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  hoverinfo .
+        ///     Sets the source reference on Chart Studio Cloud for <c>hoverinfo</c>.
         /// </summary>
         [JsonPropertyName(@"hoverinfosrc")]
         public string HoverInfoSrc { get; set;} 
@@ -143,7 +143,7 @@ namespace Plotly.Blazor.Traces
         public IList<string> HoverTemplateArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  hovertemplate .
+        ///     Sets the source reference on Chart Studio Cloud for <c>hovertemplate</c>.
         /// </summary>
         [JsonPropertyName(@"hovertemplatesrc")]
         public string HoverTemplateSrc { get; set;} 
@@ -168,7 +168,7 @@ namespace Plotly.Blazor.Traces
         public IList<string> HoverTextArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  hovertext .
+        ///     Sets the source reference on Chart Studio Cloud for <c>hovertext</c>.
         /// </summary>
         [JsonPropertyName(@"hovertextsrc")]
         public string HoverTextSrc { get; set;} 
@@ -182,7 +182,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> Ids { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  ids .
+        ///     Sets the source reference on Chart Studio Cloud for <c>ids</c>.
         /// </summary>
         [JsonPropertyName(@"idssrc")]
         public string IdsSrc { get; set;} 
@@ -200,7 +200,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> Labels { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  labels .
+        ///     Sets the source reference on Chart Studio Cloud for <c>labels</c>.
         /// </summary>
         [JsonPropertyName(@"labelssrc")]
         public string LabelsSrc { get; set;} 
@@ -273,7 +273,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> MetaArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  meta .
+        ///     Sets the source reference on Chart Studio Cloud for <c>meta</c>.
         /// </summary>
         [JsonPropertyName(@"metasrc")]
         public string MetaSrc { get; set;} 
@@ -310,7 +310,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> Parents { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  parents .
+        ///     Sets the source reference on Chart Studio Cloud for <c>parents</c>.
         /// </summary>
         [JsonPropertyName(@"parentssrc")]
         public string ParentsSrc { get; set;} 
@@ -367,7 +367,7 @@ namespace Plotly.Blazor.Traces
         public Plotly.Blazor.Traces.TreeMapLib.TextPositionEnum? TextPosition { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  text .
+        ///     Sets the source reference on Chart Studio Cloud for <c>text</c>.
         /// </summary>
         [JsonPropertyName(@"textsrc")]
         public string TextSrc { get; set;} 
@@ -408,7 +408,7 @@ namespace Plotly.Blazor.Traces
         public IList<string> TextTemplateArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  texttemplate .
+        ///     Sets the source reference on Chart Studio Cloud for <c>texttemplate</c>.
         /// </summary>
         [JsonPropertyName(@"texttemplatesrc")]
         public string TextTemplateSrc { get; set;} 
@@ -457,7 +457,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> Values { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  values .
+        ///     Sets the source reference on Chart Studio Cloud for <c>values</c>.
         /// </summary>
         [JsonPropertyName(@"valuessrc")]
         public string ValuesSrc { get; set;} 

--- a/Plotly.Blazor/Traces/TreeMapLib/HoverLabel.cs
+++ b/Plotly.Blazor/Traces/TreeMapLib/HoverLabel.cs
@@ -36,7 +36,7 @@ namespace Plotly.Blazor.Traces.TreeMapLib
         public IList<Plotly.Blazor.Traces.TreeMapLib.HoverLabelLib.AlignEnum?> AlignArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  align .
+        ///     Sets the source reference on Chart Studio Cloud for <c>align</c>.
         /// </summary>
         [JsonPropertyName(@"alignsrc")]
         public string AlignSrc { get; set;} 
@@ -55,7 +55,7 @@ namespace Plotly.Blazor.Traces.TreeMapLib
         public IList<object> BgColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  bgcolor .
+        ///     Sets the source reference on Chart Studio Cloud for <c>bgcolor</c>.
         /// </summary>
         [JsonPropertyName(@"bgcolorsrc")]
         public string BgColorSrc { get; set;} 
@@ -74,7 +74,7 @@ namespace Plotly.Blazor.Traces.TreeMapLib
         public IList<object> BorderColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  bordercolor .
+        ///     Sets the source reference on Chart Studio Cloud for <c>bordercolor</c>.
         /// </summary>
         [JsonPropertyName(@"bordercolorsrc")]
         public string BorderColorSrc { get; set;} 
@@ -107,7 +107,7 @@ namespace Plotly.Blazor.Traces.TreeMapLib
         public IList<int?> NameLengthArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  namelength .
+        ///     Sets the source reference on Chart Studio Cloud for <c>namelength</c>.
         /// </summary>
         [JsonPropertyName(@"namelengthsrc")]
         public string NameLengthSrc { get; set;} 

--- a/Plotly.Blazor/Traces/TreeMapLib/HoverLabelLib/Font.cs
+++ b/Plotly.Blazor/Traces/TreeMapLib/HoverLabelLib/Font.cs
@@ -34,7 +34,7 @@ namespace Plotly.Blazor.Traces.TreeMapLib.HoverLabelLib
         public IList<object> ColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  color .
+        ///     Sets the source reference on Chart Studio Cloud for <c>color</c>.
         /// </summary>
         [JsonPropertyName(@"colorsrc")]
         public string ColorSrc { get; set;} 
@@ -73,7 +73,7 @@ namespace Plotly.Blazor.Traces.TreeMapLib.HoverLabelLib
         public IList<string> FamilyArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  family .
+        ///     Sets the source reference on Chart Studio Cloud for <c>family</c>.
         /// </summary>
         [JsonPropertyName(@"familysrc")]
         public string FamilySrc { get; set;} 
@@ -92,7 +92,7 @@ namespace Plotly.Blazor.Traces.TreeMapLib.HoverLabelLib
         public IList<decimal?> SizeArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  size .
+        ///     Sets the source reference on Chart Studio Cloud for <c>size</c>.
         /// </summary>
         [JsonPropertyName(@"sizesrc")]
         public string SizeSrc { get; set;} 

--- a/Plotly.Blazor/Traces/TreeMapLib/InsideTextFont.cs
+++ b/Plotly.Blazor/Traces/TreeMapLib/InsideTextFont.cs
@@ -34,7 +34,7 @@ namespace Plotly.Blazor.Traces.TreeMapLib
         public IList<object> ColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  color .
+        ///     Sets the source reference on Chart Studio Cloud for <c>color</c>.
         /// </summary>
         [JsonPropertyName(@"colorsrc")]
         public string ColorSrc { get; set;} 
@@ -73,7 +73,7 @@ namespace Plotly.Blazor.Traces.TreeMapLib
         public IList<string> FamilyArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  family .
+        ///     Sets the source reference on Chart Studio Cloud for <c>family</c>.
         /// </summary>
         [JsonPropertyName(@"familysrc")]
         public string FamilySrc { get; set;} 
@@ -92,7 +92,7 @@ namespace Plotly.Blazor.Traces.TreeMapLib
         public IList<decimal?> SizeArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  size .
+        ///     Sets the source reference on Chart Studio Cloud for <c>size</c>.
         /// </summary>
         [JsonPropertyName(@"sizesrc")]
         public string SizeSrc { get; set;} 

--- a/Plotly.Blazor/Traces/TreeMapLib/Marker.cs
+++ b/Plotly.Blazor/Traces/TreeMapLib/Marker.cs
@@ -101,7 +101,7 @@ namespace Plotly.Blazor.Traces.TreeMapLib
         public object ColorScale { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  colors .
+        ///     Sets the source reference on Chart Studio Cloud for <c>colors</c>.
         /// </summary>
         [JsonPropertyName(@"colorssrc")]
         public string ColorsSrc { get; set;} 

--- a/Plotly.Blazor/Traces/TreeMapLib/MarkerLib/Line.cs
+++ b/Plotly.Blazor/Traces/TreeMapLib/MarkerLib/Line.cs
@@ -36,7 +36,7 @@ namespace Plotly.Blazor.Traces.TreeMapLib.MarkerLib
         public IList<object> ColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  color .
+        ///     Sets the source reference on Chart Studio Cloud for <c>color</c>.
         /// </summary>
         [JsonPropertyName(@"colorsrc")]
         public string ColorSrc { get; set;} 
@@ -55,7 +55,7 @@ namespace Plotly.Blazor.Traces.TreeMapLib.MarkerLib
         public IList<decimal?> WidthArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  width .
+        ///     Sets the source reference on Chart Studio Cloud for <c>width</c>.
         /// </summary>
         [JsonPropertyName(@"widthsrc")]
         public string WidthSrc { get; set;} 

--- a/Plotly.Blazor/Traces/TreeMapLib/OutsideTextFont.cs
+++ b/Plotly.Blazor/Traces/TreeMapLib/OutsideTextFont.cs
@@ -34,7 +34,7 @@ namespace Plotly.Blazor.Traces.TreeMapLib
         public IList<object> ColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  color .
+        ///     Sets the source reference on Chart Studio Cloud for <c>color</c>.
         /// </summary>
         [JsonPropertyName(@"colorsrc")]
         public string ColorSrc { get; set;} 
@@ -73,7 +73,7 @@ namespace Plotly.Blazor.Traces.TreeMapLib
         public IList<string> FamilyArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  family .
+        ///     Sets the source reference on Chart Studio Cloud for <c>family</c>.
         /// </summary>
         [JsonPropertyName(@"familysrc")]
         public string FamilySrc { get; set;} 
@@ -92,7 +92,7 @@ namespace Plotly.Blazor.Traces.TreeMapLib
         public IList<decimal?> SizeArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  size .
+        ///     Sets the source reference on Chart Studio Cloud for <c>size</c>.
         /// </summary>
         [JsonPropertyName(@"sizesrc")]
         public string SizeSrc { get; set;} 

--- a/Plotly.Blazor/Traces/TreeMapLib/PathBarLib/TextFont.cs
+++ b/Plotly.Blazor/Traces/TreeMapLib/PathBarLib/TextFont.cs
@@ -34,7 +34,7 @@ namespace Plotly.Blazor.Traces.TreeMapLib.PathBarLib
         public IList<object> ColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  color .
+        ///     Sets the source reference on Chart Studio Cloud for <c>color</c>.
         /// </summary>
         [JsonPropertyName(@"colorsrc")]
         public string ColorSrc { get; set;} 
@@ -73,7 +73,7 @@ namespace Plotly.Blazor.Traces.TreeMapLib.PathBarLib
         public IList<string> FamilyArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  family .
+        ///     Sets the source reference on Chart Studio Cloud for <c>family</c>.
         /// </summary>
         [JsonPropertyName(@"familysrc")]
         public string FamilySrc { get; set;} 
@@ -92,7 +92,7 @@ namespace Plotly.Blazor.Traces.TreeMapLib.PathBarLib
         public IList<decimal?> SizeArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  size .
+        ///     Sets the source reference on Chart Studio Cloud for <c>size</c>.
         /// </summary>
         [JsonPropertyName(@"sizesrc")]
         public string SizeSrc { get; set;} 

--- a/Plotly.Blazor/Traces/TreeMapLib/TextFont.cs
+++ b/Plotly.Blazor/Traces/TreeMapLib/TextFont.cs
@@ -34,7 +34,7 @@ namespace Plotly.Blazor.Traces.TreeMapLib
         public IList<object> ColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  color .
+        ///     Sets the source reference on Chart Studio Cloud for <c>color</c>.
         /// </summary>
         [JsonPropertyName(@"colorsrc")]
         public string ColorSrc { get; set;} 
@@ -73,7 +73,7 @@ namespace Plotly.Blazor.Traces.TreeMapLib
         public IList<string> FamilyArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  family .
+        ///     Sets the source reference on Chart Studio Cloud for <c>family</c>.
         /// </summary>
         [JsonPropertyName(@"familysrc")]
         public string FamilySrc { get; set;} 
@@ -92,7 +92,7 @@ namespace Plotly.Blazor.Traces.TreeMapLib
         public IList<decimal?> SizeArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  size .
+        ///     Sets the source reference on Chart Studio Cloud for <c>size</c>.
         /// </summary>
         [JsonPropertyName(@"sizesrc")]
         public string SizeSrc { get; set;} 

--- a/Plotly.Blazor/Traces/Violin.cs
+++ b/Plotly.Blazor/Traces/Violin.cs
@@ -55,7 +55,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> CustomData { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  customdata .
+        ///     Sets the source reference on Chart Studio Cloud for <c>customdata</c>.
         /// </summary>
         [JsonPropertyName(@"customdatasrc")]
         public string CustomDataSrc { get; set;} 
@@ -85,7 +85,7 @@ namespace Plotly.Blazor.Traces
         public IList<Plotly.Blazor.Traces.ViolinLib.HoverInfoFlag?> HoverInfoArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  hoverinfo .
+        ///     Sets the source reference on Chart Studio Cloud for <c>hoverinfo</c>.
         /// </summary>
         [JsonPropertyName(@"hoverinfosrc")]
         public string HoverInfoSrc { get; set;} 
@@ -153,7 +153,7 @@ namespace Plotly.Blazor.Traces
         public IList<string> HoverTemplateArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  hovertemplate .
+        ///     Sets the source reference on Chart Studio Cloud for <c>hovertemplate</c>.
         /// </summary>
         [JsonPropertyName(@"hovertemplatesrc")]
         public string HoverTemplateSrc { get; set;} 
@@ -172,7 +172,7 @@ namespace Plotly.Blazor.Traces
         public IList<string> HoverTextArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  hovertext .
+        ///     Sets the source reference on Chart Studio Cloud for <c>hovertext</c>.
         /// </summary>
         [JsonPropertyName(@"hovertextsrc")]
         public string HoverTextSrc { get; set;} 
@@ -186,7 +186,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> Ids { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  ids .
+        ///     Sets the source reference on Chart Studio Cloud for <c>ids</c>.
         /// </summary>
         [JsonPropertyName(@"idssrc")]
         public string IdsSrc { get; set;} 
@@ -270,7 +270,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> MetaArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  meta .
+        ///     Sets the source reference on Chart Studio Cloud for <c>meta</c>.
         /// </summary>
         [JsonPropertyName(@"metasrc")]
         public string MetaSrc { get; set;} 
@@ -422,7 +422,7 @@ namespace Plotly.Blazor.Traces
         public IList<string> TextArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  text .
+        ///     Sets the source reference on Chart Studio Cloud for <c>text</c>.
         /// </summary>
         [JsonPropertyName(@"textsrc")]
         public string TextSrc { get; set;} 
@@ -514,7 +514,7 @@ namespace Plotly.Blazor.Traces
         public string XHoverFormat { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  x .
+        ///     Sets the source reference on Chart Studio Cloud for <c>x</c>.
         /// </summary>
         [JsonPropertyName(@"xsrc")]
         public string XSrc { get; set;} 
@@ -554,7 +554,7 @@ namespace Plotly.Blazor.Traces
         public string YHoverFormat { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  y .
+        ///     Sets the source reference on Chart Studio Cloud for <c>y</c>.
         /// </summary>
         [JsonPropertyName(@"ysrc")]
         public string YSrc { get; set;} 

--- a/Plotly.Blazor/Traces/ViolinLib/HoverLabel.cs
+++ b/Plotly.Blazor/Traces/ViolinLib/HoverLabel.cs
@@ -36,7 +36,7 @@ namespace Plotly.Blazor.Traces.ViolinLib
         public IList<Plotly.Blazor.Traces.ViolinLib.HoverLabelLib.AlignEnum?> AlignArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  align .
+        ///     Sets the source reference on Chart Studio Cloud for <c>align</c>.
         /// </summary>
         [JsonPropertyName(@"alignsrc")]
         public string AlignSrc { get; set;} 
@@ -55,7 +55,7 @@ namespace Plotly.Blazor.Traces.ViolinLib
         public IList<object> BgColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  bgcolor .
+        ///     Sets the source reference on Chart Studio Cloud for <c>bgcolor</c>.
         /// </summary>
         [JsonPropertyName(@"bgcolorsrc")]
         public string BgColorSrc { get; set;} 
@@ -74,7 +74,7 @@ namespace Plotly.Blazor.Traces.ViolinLib
         public IList<object> BorderColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  bordercolor .
+        ///     Sets the source reference on Chart Studio Cloud for <c>bordercolor</c>.
         /// </summary>
         [JsonPropertyName(@"bordercolorsrc")]
         public string BorderColorSrc { get; set;} 
@@ -107,7 +107,7 @@ namespace Plotly.Blazor.Traces.ViolinLib
         public IList<int?> NameLengthArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  namelength .
+        ///     Sets the source reference on Chart Studio Cloud for <c>namelength</c>.
         /// </summary>
         [JsonPropertyName(@"namelengthsrc")]
         public string NameLengthSrc { get; set;} 

--- a/Plotly.Blazor/Traces/ViolinLib/HoverLabelLib/Font.cs
+++ b/Plotly.Blazor/Traces/ViolinLib/HoverLabelLib/Font.cs
@@ -34,7 +34,7 @@ namespace Plotly.Blazor.Traces.ViolinLib.HoverLabelLib
         public IList<object> ColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  color .
+        ///     Sets the source reference on Chart Studio Cloud for <c>color</c>.
         /// </summary>
         [JsonPropertyName(@"colorsrc")]
         public string ColorSrc { get; set;} 
@@ -73,7 +73,7 @@ namespace Plotly.Blazor.Traces.ViolinLib.HoverLabelLib
         public IList<string> FamilyArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  family .
+        ///     Sets the source reference on Chart Studio Cloud for <c>family</c>.
         /// </summary>
         [JsonPropertyName(@"familysrc")]
         public string FamilySrc { get; set;} 
@@ -92,7 +92,7 @@ namespace Plotly.Blazor.Traces.ViolinLib.HoverLabelLib
         public IList<decimal?> SizeArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  size .
+        ///     Sets the source reference on Chart Studio Cloud for <c>size</c>.
         /// </summary>
         [JsonPropertyName(@"sizesrc")]
         public string SizeSrc { get; set;} 

--- a/Plotly.Blazor/Traces/Volume.cs
+++ b/Plotly.Blazor/Traces/Volume.cs
@@ -115,7 +115,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> CustomData { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  customdata .
+        ///     Sets the source reference on Chart Studio Cloud for <c>customdata</c>.
         /// </summary>
         [JsonPropertyName(@"customdatasrc")]
         public string CustomDataSrc { get; set;} 
@@ -145,7 +145,7 @@ namespace Plotly.Blazor.Traces
         public IList<Plotly.Blazor.Traces.VolumeLib.HoverInfoFlag?> HoverInfoArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  hoverinfo .
+        ///     Sets the source reference on Chart Studio Cloud for <c>hoverinfo</c>.
         /// </summary>
         [JsonPropertyName(@"hoverinfosrc")]
         public string HoverInfoSrc { get; set;} 
@@ -206,7 +206,7 @@ namespace Plotly.Blazor.Traces
         public IList<string> HoverTemplateArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  hovertemplate .
+        ///     Sets the source reference on Chart Studio Cloud for <c>hovertemplate</c>.
         /// </summary>
         [JsonPropertyName(@"hovertemplatesrc")]
         public string HoverTemplateSrc { get; set;} 
@@ -225,7 +225,7 @@ namespace Plotly.Blazor.Traces
         public IList<string> HoverTextArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  hovertext .
+        ///     Sets the source reference on Chart Studio Cloud for <c>hovertext</c>.
         /// </summary>
         [JsonPropertyName(@"hovertextsrc")]
         public string HoverTextSrc { get; set;} 
@@ -239,7 +239,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> Ids { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  ids .
+        ///     Sets the source reference on Chart Studio Cloud for <c>ids</c>.
         /// </summary>
         [JsonPropertyName(@"idssrc")]
         public string IdsSrc { get; set;} 
@@ -321,7 +321,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> MetaArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  meta .
+        ///     Sets the source reference on Chart Studio Cloud for <c>meta</c>.
         /// </summary>
         [JsonPropertyName(@"metasrc")]
         public string MetaSrc { get; set;} 
@@ -427,7 +427,7 @@ namespace Plotly.Blazor.Traces
         public IList<string> TextArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  text .
+        ///     Sets the source reference on Chart Studio Cloud for <c>text</c>.
         /// </summary>
         [JsonPropertyName(@"textsrc")]
         public string TextSrc { get; set;} 
@@ -472,7 +472,7 @@ namespace Plotly.Blazor.Traces
         public string ValueHoverFormat { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  value .
+        ///     Sets the source reference on Chart Studio Cloud for <c>value</c>.
         /// </summary>
         [JsonPropertyName(@"valuesrc")]
         public string ValueSrc { get; set;} 
@@ -505,7 +505,7 @@ namespace Plotly.Blazor.Traces
         public string XHoverFormat { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  x .
+        ///     Sets the source reference on Chart Studio Cloud for <c>x</c>.
         /// </summary>
         [JsonPropertyName(@"xsrc")]
         public string XSrc { get; set;} 
@@ -530,7 +530,7 @@ namespace Plotly.Blazor.Traces
         public string YHoverFormat { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  y .
+        ///     Sets the source reference on Chart Studio Cloud for <c>y</c>.
         /// </summary>
         [JsonPropertyName(@"ysrc")]
         public string YSrc { get; set;} 
@@ -555,7 +555,7 @@ namespace Plotly.Blazor.Traces
         public string ZHoverFormat { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  z .
+        ///     Sets the source reference on Chart Studio Cloud for <c>z</c>.
         /// </summary>
         [JsonPropertyName(@"zsrc")]
         public string ZSrc { get; set;} 

--- a/Plotly.Blazor/Traces/VolumeLib/HoverLabel.cs
+++ b/Plotly.Blazor/Traces/VolumeLib/HoverLabel.cs
@@ -36,7 +36,7 @@ namespace Plotly.Blazor.Traces.VolumeLib
         public IList<Plotly.Blazor.Traces.VolumeLib.HoverLabelLib.AlignEnum?> AlignArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  align .
+        ///     Sets the source reference on Chart Studio Cloud for <c>align</c>.
         /// </summary>
         [JsonPropertyName(@"alignsrc")]
         public string AlignSrc { get; set;} 
@@ -55,7 +55,7 @@ namespace Plotly.Blazor.Traces.VolumeLib
         public IList<object> BgColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  bgcolor .
+        ///     Sets the source reference on Chart Studio Cloud for <c>bgcolor</c>.
         /// </summary>
         [JsonPropertyName(@"bgcolorsrc")]
         public string BgColorSrc { get; set;} 
@@ -74,7 +74,7 @@ namespace Plotly.Blazor.Traces.VolumeLib
         public IList<object> BorderColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  bordercolor .
+        ///     Sets the source reference on Chart Studio Cloud for <c>bordercolor</c>.
         /// </summary>
         [JsonPropertyName(@"bordercolorsrc")]
         public string BorderColorSrc { get; set;} 
@@ -107,7 +107,7 @@ namespace Plotly.Blazor.Traces.VolumeLib
         public IList<int?> NameLengthArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  namelength .
+        ///     Sets the source reference on Chart Studio Cloud for <c>namelength</c>.
         /// </summary>
         [JsonPropertyName(@"namelengthsrc")]
         public string NameLengthSrc { get; set;} 

--- a/Plotly.Blazor/Traces/VolumeLib/HoverLabelLib/Font.cs
+++ b/Plotly.Blazor/Traces/VolumeLib/HoverLabelLib/Font.cs
@@ -34,7 +34,7 @@ namespace Plotly.Blazor.Traces.VolumeLib.HoverLabelLib
         public IList<object> ColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  color .
+        ///     Sets the source reference on Chart Studio Cloud for <c>color</c>.
         /// </summary>
         [JsonPropertyName(@"colorsrc")]
         public string ColorSrc { get; set;} 
@@ -73,7 +73,7 @@ namespace Plotly.Blazor.Traces.VolumeLib.HoverLabelLib
         public IList<string> FamilyArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  family .
+        ///     Sets the source reference on Chart Studio Cloud for <c>family</c>.
         /// </summary>
         [JsonPropertyName(@"familysrc")]
         public string FamilySrc { get; set;} 
@@ -92,7 +92,7 @@ namespace Plotly.Blazor.Traces.VolumeLib.HoverLabelLib
         public IList<decimal?> SizeArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  size .
+        ///     Sets the source reference on Chart Studio Cloud for <c>size</c>.
         /// </summary>
         [JsonPropertyName(@"sizesrc")]
         public string SizeSrc { get; set;} 

--- a/Plotly.Blazor/Traces/VolumeLib/SlicesLib/X.cs
+++ b/Plotly.Blazor/Traces/VolumeLib/SlicesLib/X.cs
@@ -36,7 +36,7 @@ namespace Plotly.Blazor.Traces.VolumeLib.SlicesLib
         public IList<object> Locations { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  locations .
+        ///     Sets the source reference on Chart Studio Cloud for <c>locations</c>.
         /// </summary>
         [JsonPropertyName(@"locationssrc")]
         public string LocationsSrc { get; set;} 

--- a/Plotly.Blazor/Traces/VolumeLib/SlicesLib/Y.cs
+++ b/Plotly.Blazor/Traces/VolumeLib/SlicesLib/Y.cs
@@ -36,7 +36,7 @@ namespace Plotly.Blazor.Traces.VolumeLib.SlicesLib
         public IList<object> Locations { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  locations .
+        ///     Sets the source reference on Chart Studio Cloud for <c>locations</c>.
         /// </summary>
         [JsonPropertyName(@"locationssrc")]
         public string LocationsSrc { get; set;} 

--- a/Plotly.Blazor/Traces/VolumeLib/SlicesLib/Z.cs
+++ b/Plotly.Blazor/Traces/VolumeLib/SlicesLib/Z.cs
@@ -36,7 +36,7 @@ namespace Plotly.Blazor.Traces.VolumeLib.SlicesLib
         public IList<object> Locations { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  locations .
+        ///     Sets the source reference on Chart Studio Cloud for <c>locations</c>.
         /// </summary>
         [JsonPropertyName(@"locationssrc")]
         public string LocationsSrc { get; set;} 

--- a/Plotly.Blazor/Traces/Waterfall.cs
+++ b/Plotly.Blazor/Traces/Waterfall.cs
@@ -69,7 +69,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> CustomData { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  customdata .
+        ///     Sets the source reference on Chart Studio Cloud for <c>customdata</c>.
         /// </summary>
         [JsonPropertyName(@"customdatasrc")]
         public string CustomDataSrc { get; set;} 
@@ -110,7 +110,7 @@ namespace Plotly.Blazor.Traces
         public IList<Plotly.Blazor.Traces.WaterfallLib.HoverInfoFlag?> HoverInfoArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  hoverinfo .
+        ///     Sets the source reference on Chart Studio Cloud for <c>hoverinfo</c>.
         /// </summary>
         [JsonPropertyName(@"hoverinfosrc")]
         public string HoverInfoSrc { get; set;} 
@@ -171,7 +171,7 @@ namespace Plotly.Blazor.Traces
         public IList<string> HoverTemplateArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  hovertemplate .
+        ///     Sets the source reference on Chart Studio Cloud for <c>hovertemplate</c>.
         /// </summary>
         [JsonPropertyName(@"hovertemplatesrc")]
         public string HoverTemplateSrc { get; set;} 
@@ -196,7 +196,7 @@ namespace Plotly.Blazor.Traces
         public IList<string> HoverTextArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  hovertext .
+        ///     Sets the source reference on Chart Studio Cloud for <c>hovertext</c>.
         /// </summary>
         [JsonPropertyName(@"hovertextsrc")]
         public string HoverTextSrc { get; set;} 
@@ -210,7 +210,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> Ids { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  ids .
+        ///     Sets the source reference on Chart Studio Cloud for <c>ids</c>.
         /// </summary>
         [JsonPropertyName(@"idssrc")]
         public string IdsSrc { get; set;} 
@@ -267,7 +267,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> Measure { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  measure .
+        ///     Sets the source reference on Chart Studio Cloud for <c>measure</c>.
         /// </summary>
         [JsonPropertyName(@"measuresrc")]
         public string MeasureSrc { get; set;} 
@@ -302,7 +302,7 @@ namespace Plotly.Blazor.Traces
         public IList<object> MetaArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  meta .
+        ///     Sets the source reference on Chart Studio Cloud for <c>meta</c>.
         /// </summary>
         [JsonPropertyName(@"metasrc")]
         public string MetaSrc { get; set;} 
@@ -339,7 +339,7 @@ namespace Plotly.Blazor.Traces
         public string OffsetGroup { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  offset .
+        ///     Sets the source reference on Chart Studio Cloud for <c>offset</c>.
         /// </summary>
         [JsonPropertyName(@"offsetsrc")]
         public string OffsetSrc { get; set;} 
@@ -454,13 +454,13 @@ namespace Plotly.Blazor.Traces
         public IList<Plotly.Blazor.Traces.WaterfallLib.TextPositionEnum?> TextPositionArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  textposition .
+        ///     Sets the source reference on Chart Studio Cloud for <c>textposition</c>.
         /// </summary>
         [JsonPropertyName(@"textpositionsrc")]
         public string TextPositionSrc { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  text .
+        ///     Sets the source reference on Chart Studio Cloud for <c>text</c>.
         /// </summary>
         [JsonPropertyName(@"textsrc")]
         public string TextSrc { get; set;} 
@@ -499,7 +499,7 @@ namespace Plotly.Blazor.Traces
         public IList<string> TextTemplateArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  texttemplate .
+        ///     Sets the source reference on Chart Studio Cloud for <c>texttemplate</c>.
         /// </summary>
         [JsonPropertyName(@"texttemplatesrc")]
         public string TextTemplateSrc { get; set;} 
@@ -562,7 +562,7 @@ namespace Plotly.Blazor.Traces
         public IList<decimal?> WidthArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  width .
+        ///     Sets the source reference on Chart Studio Cloud for <c>width</c>.
         /// </summary>
         [JsonPropertyName(@"widthsrc")]
         public string WidthSrc { get; set;} 
@@ -627,7 +627,7 @@ namespace Plotly.Blazor.Traces
         public Plotly.Blazor.Traces.WaterfallLib.XPeriodAlignmentEnum? XPeriodAlignment { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  x .
+        ///     Sets the source reference on Chart Studio Cloud for <c>x</c>.
         /// </summary>
         [JsonPropertyName(@"xsrc")]
         public string XSrc { get; set;} 
@@ -692,7 +692,7 @@ namespace Plotly.Blazor.Traces
         public Plotly.Blazor.Traces.WaterfallLib.YPeriodAlignmentEnum? YPeriodAlignment { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  y .
+        ///     Sets the source reference on Chart Studio Cloud for <c>y</c>.
         /// </summary>
         [JsonPropertyName(@"ysrc")]
         public string YSrc { get; set;} 

--- a/Plotly.Blazor/Traces/WaterfallLib/HoverLabel.cs
+++ b/Plotly.Blazor/Traces/WaterfallLib/HoverLabel.cs
@@ -36,7 +36,7 @@ namespace Plotly.Blazor.Traces.WaterfallLib
         public IList<Plotly.Blazor.Traces.WaterfallLib.HoverLabelLib.AlignEnum?> AlignArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  align .
+        ///     Sets the source reference on Chart Studio Cloud for <c>align</c>.
         /// </summary>
         [JsonPropertyName(@"alignsrc")]
         public string AlignSrc { get; set;} 
@@ -55,7 +55,7 @@ namespace Plotly.Blazor.Traces.WaterfallLib
         public IList<object> BgColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  bgcolor .
+        ///     Sets the source reference on Chart Studio Cloud for <c>bgcolor</c>.
         /// </summary>
         [JsonPropertyName(@"bgcolorsrc")]
         public string BgColorSrc { get; set;} 
@@ -74,7 +74,7 @@ namespace Plotly.Blazor.Traces.WaterfallLib
         public IList<object> BorderColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  bordercolor .
+        ///     Sets the source reference on Chart Studio Cloud for <c>bordercolor</c>.
         /// </summary>
         [JsonPropertyName(@"bordercolorsrc")]
         public string BorderColorSrc { get; set;} 
@@ -107,7 +107,7 @@ namespace Plotly.Blazor.Traces.WaterfallLib
         public IList<int?> NameLengthArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  namelength .
+        ///     Sets the source reference on Chart Studio Cloud for <c>namelength</c>.
         /// </summary>
         [JsonPropertyName(@"namelengthsrc")]
         public string NameLengthSrc { get; set;} 

--- a/Plotly.Blazor/Traces/WaterfallLib/HoverLabelLib/Font.cs
+++ b/Plotly.Blazor/Traces/WaterfallLib/HoverLabelLib/Font.cs
@@ -34,7 +34,7 @@ namespace Plotly.Blazor.Traces.WaterfallLib.HoverLabelLib
         public IList<object> ColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  color .
+        ///     Sets the source reference on Chart Studio Cloud for <c>color</c>.
         /// </summary>
         [JsonPropertyName(@"colorsrc")]
         public string ColorSrc { get; set;} 
@@ -73,7 +73,7 @@ namespace Plotly.Blazor.Traces.WaterfallLib.HoverLabelLib
         public IList<string> FamilyArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  family .
+        ///     Sets the source reference on Chart Studio Cloud for <c>family</c>.
         /// </summary>
         [JsonPropertyName(@"familysrc")]
         public string FamilySrc { get; set;} 
@@ -92,7 +92,7 @@ namespace Plotly.Blazor.Traces.WaterfallLib.HoverLabelLib
         public IList<decimal?> SizeArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  size .
+        ///     Sets the source reference on Chart Studio Cloud for <c>size</c>.
         /// </summary>
         [JsonPropertyName(@"sizesrc")]
         public string SizeSrc { get; set;} 

--- a/Plotly.Blazor/Traces/WaterfallLib/InsideTextFont.cs
+++ b/Plotly.Blazor/Traces/WaterfallLib/InsideTextFont.cs
@@ -34,7 +34,7 @@ namespace Plotly.Blazor.Traces.WaterfallLib
         public IList<object> ColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  color .
+        ///     Sets the source reference on Chart Studio Cloud for <c>color</c>.
         /// </summary>
         [JsonPropertyName(@"colorsrc")]
         public string ColorSrc { get; set;} 
@@ -73,7 +73,7 @@ namespace Plotly.Blazor.Traces.WaterfallLib
         public IList<string> FamilyArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  family .
+        ///     Sets the source reference on Chart Studio Cloud for <c>family</c>.
         /// </summary>
         [JsonPropertyName(@"familysrc")]
         public string FamilySrc { get; set;} 
@@ -92,7 +92,7 @@ namespace Plotly.Blazor.Traces.WaterfallLib
         public IList<decimal?> SizeArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  size .
+        ///     Sets the source reference on Chart Studio Cloud for <c>size</c>.
         /// </summary>
         [JsonPropertyName(@"sizesrc")]
         public string SizeSrc { get; set;} 

--- a/Plotly.Blazor/Traces/WaterfallLib/OutsideTextFont.cs
+++ b/Plotly.Blazor/Traces/WaterfallLib/OutsideTextFont.cs
@@ -34,7 +34,7 @@ namespace Plotly.Blazor.Traces.WaterfallLib
         public IList<object> ColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  color .
+        ///     Sets the source reference on Chart Studio Cloud for <c>color</c>.
         /// </summary>
         [JsonPropertyName(@"colorsrc")]
         public string ColorSrc { get; set;} 
@@ -73,7 +73,7 @@ namespace Plotly.Blazor.Traces.WaterfallLib
         public IList<string> FamilyArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  family .
+        ///     Sets the source reference on Chart Studio Cloud for <c>family</c>.
         /// </summary>
         [JsonPropertyName(@"familysrc")]
         public string FamilySrc { get; set;} 
@@ -92,7 +92,7 @@ namespace Plotly.Blazor.Traces.WaterfallLib
         public IList<decimal?> SizeArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  size .
+        ///     Sets the source reference on Chart Studio Cloud for <c>size</c>.
         /// </summary>
         [JsonPropertyName(@"sizesrc")]
         public string SizeSrc { get; set;} 

--- a/Plotly.Blazor/Traces/WaterfallLib/TextFont.cs
+++ b/Plotly.Blazor/Traces/WaterfallLib/TextFont.cs
@@ -34,7 +34,7 @@ namespace Plotly.Blazor.Traces.WaterfallLib
         public IList<object> ColorArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  color .
+        ///     Sets the source reference on Chart Studio Cloud for <c>color</c>.
         /// </summary>
         [JsonPropertyName(@"colorsrc")]
         public string ColorSrc { get; set;} 
@@ -73,7 +73,7 @@ namespace Plotly.Blazor.Traces.WaterfallLib
         public IList<string> FamilyArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  family .
+        ///     Sets the source reference on Chart Studio Cloud for <c>family</c>.
         /// </summary>
         [JsonPropertyName(@"familysrc")]
         public string FamilySrc { get; set;} 
@@ -92,7 +92,7 @@ namespace Plotly.Blazor.Traces.WaterfallLib
         public IList<decimal?> SizeArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  size .
+        ///     Sets the source reference on Chart Studio Cloud for <c>size</c>.
         /// </summary>
         [JsonPropertyName(@"sizesrc")]
         public string SizeSrc { get; set;} 

--- a/Plotly.Blazor/Transforms/Aggregate.cs
+++ b/Plotly.Blazor/Transforms/Aggregate.cs
@@ -65,7 +65,7 @@ namespace Plotly.Blazor.Transforms
         public IList<string> GroupsArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  groups .
+        ///     Sets the source reference on Chart Studio Cloud for <c>groups</c>.
         /// </summary>
         [JsonPropertyName(@"groupssrc")]
         public string GroupsSrc { get; set;} 

--- a/Plotly.Blazor/Transforms/Filter.cs
+++ b/Plotly.Blazor/Transforms/Filter.cs
@@ -94,7 +94,7 @@ namespace Plotly.Blazor.Transforms
         public Plotly.Blazor.Transforms.FilterLib.TargetCalendarEnum? TargetCalendar { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  target .
+        ///     Sets the source reference on Chart Studio Cloud for <c>target</c>.
         /// </summary>
         [JsonPropertyName(@"targetsrc")]
         public string TargetSrc { get; set;} 

--- a/Plotly.Blazor/Transforms/GroupBy.cs
+++ b/Plotly.Blazor/Transforms/GroupBy.cs
@@ -40,7 +40,7 @@ namespace Plotly.Blazor.Transforms
         public IList<object> Groups { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  groups .
+        ///     Sets the source reference on Chart Studio Cloud for <c>groups</c>.
         /// </summary>
         [JsonPropertyName(@"groupssrc")]
         public string GroupsSrc { get; set;} 

--- a/Plotly.Blazor/Transforms/Sort.cs
+++ b/Plotly.Blazor/Transforms/Sort.cs
@@ -61,7 +61,7 @@ namespace Plotly.Blazor.Transforms
         public IList<string> TargetArray { get; set;} 
 
         /// <summary>
-        ///     Sets the source reference on Chart Studio Cloud for  target .
+        ///     Sets the source reference on Chart Studio Cloud for <c>target</c>.
         /// </summary>
         [JsonPropertyName(@"targetsrc")]
         public string TargetSrc { get; set;} 


### PR DESCRIPTION
Ran Plotly.Blazor.Generator which picked up the latest schema and committed files with comment only changes.

Mostly addition of <c> around references
Split these out from other changes present in 2.9
