### PR TITLE
SetParameters before null checks

### DIFF
--- a/Plotly.Blazor.Generator/src/PlotlyChart.razor
+++ b/Plotly.Blazor.Generator/src/PlotlyChart.razor
@@ -85,7 +85,10 @@
     /// <inheritdoc />
     public override async Task SetParametersAsync(ParameterView parameters)
     {
-        objectReference = DotNetObjectReference.Create(this);
+        await base.SetParametersAsync(parameters);
+        
+        objectReference ??= DotNetObjectReference.Create(this);
+
         if (string.IsNullOrWhiteSpace(Id))
         {
             var random = new Random();
@@ -112,7 +115,6 @@
             Frames = new List<Frames>();
             await FramesChanged.InvokeAsync(Frames);
         }
-        await base.SetParametersAsync(parameters);
     }
 
     /// <inheritdoc />

--- a/Plotly.Blazor/PlotlyChart.razor
+++ b/Plotly.Blazor/PlotlyChart.razor
@@ -85,7 +85,10 @@
     /// <inheritdoc />
     public override async Task SetParametersAsync(ParameterView parameters)
     {
-        objectReference = DotNetObjectReference.Create(this);
+        await base.SetParametersAsync(parameters);
+        
+        objectReference ??= DotNetObjectReference.Create(this);
+
         if (string.IsNullOrWhiteSpace(Id))
         {
             var random = new Random();
@@ -112,7 +115,6 @@
             Frames = new List<Frames>();
             await FramesChanged.InvokeAsync(Frames);
         }
-        await base.SetParametersAsync(parameters);
     }
 
     /// <inheritdoc />


### PR DESCRIPTION
Previously on initialisation all properties (including the *Changed EventCallbacks) weren't set before the first run.
This changes to call bases first to set the properties, then perform null checks.

- Doesn't set null again in the base
- Emits changes from null check to listeners of *Changed
- Only create 1 objectReference, changing parameters would otherwise create a new one with the old one not disposed.

An example that was previously broken

``` razor
<PlotlyChart @bind-Id="id" Config="config" Layout="layout" Data="data" @ref="chart"/>

@code
{
    PlotlyChart chart;
    string id = null;
...

```

Before
> Error: DOM element provided is null or undefined
    at Object.getGraphDiv (https://localhost:5001/_content/Plotly.Blazor/plotly-latest.min.js:58:514251)
    at Object.r.newPlot (https://localhost:5001/_content/Plotly.Blazor/plotly-latest.min.js:58:613546)
    at Object.newPlot (https://localhost:5001/_content/Plotly.Blazor/plotly-interop.js:3:23)
    at https://localhost:5001/_framework/blazor.server.js:1:70369
    at new Promise (<anonymous>)
    at e.beginInvokeJSFromDotNet (https://localhost:5001/_framework/blazor.server.js:1:70335)
    at https://localhost:5001/_framework/blazor.server.js:1:26442
    at Array.forEach (<anonymous>)
    at e.invokeClientMethod (https://localhost:5001/_framework/blazor.server.js:1:26412)
    at e.processIncomingData (https://localhost:5001/_framework/blazor.server.js:1:24223)
      Microsoft.JSInterop.JSException: DOM element provided is null or undefined

Now 
`id = "PlotlyChart-1631351517"