### PR TITLE
Parameterize the inline styles applied to the chart's container

### DIFF
--- a/Plotly.Blazor/PlotlyChart.razor
+++ b/Plotly.Blazor/PlotlyChart.razor
@@ -5,7 +5,7 @@
 @using Plotly.Blazor.Interop
 @implements IDisposable
 
-<div style="min-height: 350px; height: 100%" @attributes="AdditionalAttributes" id="@Id"></div>
+<div style="@InlineStyle" @attributes="AdditionalAttributes" id="@Id"></div>
 
 @code {
 
@@ -38,6 +38,12 @@
     /// </summary>
     [Parameter]
     public IList<Frames> Frames { get; set; }
+
+    /// <summary>
+    ///     Styling applied directly to the chart area.
+    /// </summary>
+    [Parameter]
+    public string InlineStyle { get; set; } = "min-height: 350px; height: 100%";
 
     /// <summary>
     ///     Callback when the ID changed.


### PR DESCRIPTION
Create a parameter for inline styles on PlotlyChart.razor's main container, allowing developers to customize those inline styles when required. The default value for the new parameter is the original values applied directly to the container, to ensure backwards compatibility.

This is a non-breaking enhancement because the default behaviour remains unchanged.

Fixes #165