### PR TITLE
Fix Bug in Click & Hover Event Related to Charts Without X/Y Plots

### DIFF
--- a/Plotly.Blazor.Examples/Components/PieChart.razor
+++ b/Plotly.Blazor.Examples/Components/PieChart.razor
@@ -29,7 +29,7 @@
         }
     }; 
 
-    public void PieClick(object label, object value)
+    public void PieClick(object value, object label)
     {
         var l = label.ToString();
         var v = value.ToString();

--- a/Plotly.Blazor.Examples/Components/PieChart.razor
+++ b/Plotly.Blazor.Examples/Components/PieChart.razor
@@ -1,22 +1,24 @@
-﻿<PlotlyChart Id="TestId" Config="config" Layout="layout" Data="data" @ref="chart"/>
+﻿@using System.Text.Json;
+@using Plotly.Blazor.Interop;
+<PlotlyChart Id="TestId" Config="config" Layout="layout" Data="data" @ref="chart" ClickAction="PieClick" HoverAction="HoverAction" AfterRender="async () => await SubscribeEvents()" />
 
 @code
 {
     PlotlyChart chart;
 
     Config config = new Config
-    {
-        Responsive = true
-    };
+        {
+            Responsive = true
+        };
 
     Layout layout = new Layout
-    {
-        Title = new Title
         {
-            Text = "Pie"
-        },
-        Height = 500
-    };
+            Title = new Title
+            {
+                Text = "Pie"
+            },
+            Height = 500
+        };
 
     List<ITrace> data = new List<ITrace>
     {
@@ -25,5 +27,26 @@
             Values = new List<object> {19, 26, 55},
             Labels = new List<object> {"Residential", "Non-Residential", "Utility"}
         }
-    };
+    }; 
+
+    public void PieClick(object label, object value)
+    {
+        var l = label.ToString();
+        var v = value.ToString();
+    }
+
+    public void HoverAction(IEnumerable<HoverEventDataPoint> eventData)
+    {
+        var HoverInfos = eventData;
+        var value = eventData.First().X.ToString();
+        var label = eventData.First().Y.ToString();
+    }
+
+    public async Task SubscribeEvents()
+    {
+        await chart.SubscribeClickEvent();
+        await chart.SubscribeHoverEvent();
+    }
+
+
 }

--- a/Plotly.Blazor.Generator/src/wwwroot/plotly-interop.js
+++ b/Plotly.Blazor.Generator/src/wwwroot/plotly-interop.js
@@ -62,7 +62,10 @@
     subscribeClickEvent: function (dotNetObj, id) {
         var plot = document.getElementById(id);
         plot.on('plotly_click', function (data) {
-            dotNetObj.invokeMethodAsync('ClickEvent', data.points[0].x, data.points[0].y);
+            if(data.points[0].x != null)
+                dotNetObj.invokeMethodAsync('ClickEvent', data.points[0].x, data.points[0].y);
+            else
+                dotNetObj.invokeMethodAsync('ClickEvent', data.points[0].value, data.points[0].label);
         })
     },
     subscribeHoverEvent: function (dotNetObj, id) {
@@ -70,12 +73,22 @@
         plot.on('plotly_hover', function (data) {
             dotNetObj.invokeMethodAsync('HoverEvent',
                 data.points.map(function (d) {
-                    return ({
-                        TraceIndex: d.fullData.index,
-                        PointIndex: d.pointIndex,
-                        X: d.x,
-                        Y: d.y
-                    });
+                    if (d.x != null) {
+                        return ({
+                            TraceIndex: d.fullData.index,
+                            PointIndex: d.pointIndex,
+                            X: d.x,
+                            Y: d.y
+                        });
+                    }
+                    else {
+                        return ({
+                            TraceIndex: d.fullData.index,
+                            PointIndex: d.pointIndex,
+                            X: d.value,
+                            Y: d.label
+                        });
+                    }
                 }));
         })
     }

--- a/Plotly.Blazor/wwwroot/plotly-interop.js
+++ b/Plotly.Blazor/wwwroot/plotly-interop.js
@@ -62,7 +62,10 @@
     subscribeClickEvent: function (dotNetObj, id) {
         var plot = document.getElementById(id);
         plot.on('plotly_click', function (data) {
-            dotNetObj.invokeMethodAsync('ClickEvent', data.points[0].x, data.points[0].y);
+            if (data.points[0].x != null)
+                dotNetObj.invokeMethodAsync('ClickEvent', data.points[0].x, data.points[0].y);
+            else
+                dotNetObj.invokeMethodAsync('ClickEvent', data.points[0].value, data.points[0].label);
         })
     },
     subscribeHoverEvent: function (dotNetObj, id) {
@@ -70,12 +73,22 @@
         plot.on('plotly_hover', function (data) {
             dotNetObj.invokeMethodAsync('HoverEvent',
                 data.points.map(function (d) {
-                    return ({
-                        TraceIndex: d.fullData.index,
-                        PointIndex: d.pointIndex,
-                        X: d.x,
-                        Y: d.y
-                    });
+                    if (d.x != null) {
+                        return ({
+                            TraceIndex: d.fullData.index,
+                            PointIndex: d.pointIndex,
+                            X: d.x,
+                            Y: d.y
+                        });
+                    }
+                    else {
+                        return ({
+                            TraceIndex: d.fullData.index,
+                            PointIndex: d.pointIndex,
+                            X: d.value,
+                            Y: d.label
+                        });
+                    }
                 }));
         })
     }


### PR DESCRIPTION
Fixed Click and Hover Event subscribers so that they return the Value/Label for a chart if an X/Y value is not available instead of returning null. (e.g. Pie charts can now get information on which specific slice was clicked.)

Added code to Pie Chart example to demonstrate how to add Click/Hover events and retrieve the related values.