### PR TITLE
Add more HoverEventDataPoint properties

### DIFF
--- a/Plotly.Blazor/Interop/HoverEventDataPoint.cs
+++ b/Plotly.Blazor/Interop/HoverEventDataPoint.cs
@@ -17,6 +17,22 @@
         public int PointIndex { get; set; }
 
         /// <summary>
+        ///     The zero-based point number. Can be used to identify the point in combination with CurveNumber.
+        /// </summary>
+        public int? PointNumber { get; set; }
+
+        /// <summary>
+        ///     The zero-based point number. Can be used to identify the point in combination with PointNumber or PointIndex.
+        /// </summary>
+        public int? CurveNumber { get; set; }
+
+        /// <summary>
+        ///     The text-value as an object to be compatible to multiple data types.
+        ///     Has to be casted manually.
+        /// </summary>
+        public object Text { get; set; }
+
+        /// <summary>
         ///     The X-Value as an object to be compatible to multiple data types.
         ///     Has to be casted manually.
         /// </summary>
@@ -27,5 +43,11 @@
         ///     Has to be casted manually.
         /// </summary>
         public object Y { get; set; }
+
+        /// <summary>
+        ///     The Z-Value as an object to be compatible to multiple data types.
+        ///     Has to be casted manually.
+        /// </summary>
+        public object Z { get; set; }
     }
 }

--- a/Plotly.Blazor/wwwroot/plotly-interop.js
+++ b/Plotly.Blazor/wwwroot/plotly-interop.js
@@ -77,16 +77,24 @@
                         return ({
                             TraceIndex: d.fullData.index,
                             PointIndex: d.pointIndex,
+                            PointNumber: d.pointNumber,
+                            CurveNumber: d.curveNumber,
+                            Text: d.text,
                             X: d.x,
-                            Y: d.y
+                            Y: d.y,
+                            Z: d.z
                         });
                     }
                     else {
                         return ({
                             TraceIndex: d.fullData.index,
                             PointIndex: d.pointIndex,
+                            PointNumber: d.pointNumber,
+                            CurveNumber: d.curveNumber,
+                            Text: d.text,
                             X: d.value,
-                            Y: d.label
+                            Y: d.label,
+                            Z: null
                         });
                     }
                 }));


### PR DESCRIPTION
When using a Scatter3d trace, the `pointIndex` is always 0, no matter which point is hovered. Having the additional properties ensures that the code in the hover event knows which point is hovered.

It would probably be better if `pointIndex` was `int?`, because it is not set in the data the interop gets from JS. That would be a breaking change though. Thus, I didn't change that.