### PR TITLE
Enhance NuGet Experience: Publish symbol packages, Add license expression

### DIFF
--- a/Plotly.Blazor/Plotly.Blazor.csproj
+++ b/Plotly.Blazor/Plotly.Blazor.csproj
@@ -9,6 +9,12 @@
         <PackageTags>blazor plotly charting-library</PackageTags>
         <PackageProjectUrl>https://github.com/LayTec-AG/Plotly.Blazor</PackageProjectUrl>
         <Description>Plotly.Blazor is a wrapper for plotly.js. Built on top of d3.js and stack.gl, plotly.js is a high-level, declarative charting library. It ships with over 40 chart types, including 3D charts, statistical graphs, and SVG maps. plotly.js is free and open source and you can view the source, report issues or contribute on GitHub.</Description>
+        <PackageLicenseExpression>MIT</PackageLicenseExpression>
+        <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
+        <PublishRepositoryUrl>true</PublishRepositoryUrl>
+        <EmbedUntrackedSources>true</EmbedUntrackedSources>
+        <IncludeSymbols Condition=" '$(DebugType)' != 'embedded' ">true</IncludeSymbols>
+        <SymbolPackageFormat>snupkg</SymbolPackageFormat>
         <EnableNETAnalyzers>false</EnableNETAnalyzers>
     </PropertyGroup>
 


### PR DESCRIPTION
* Publishing symbol packages enables users to debug into the open source code of this library if needed
* Adding the `PackageLicenseExpression` makes it easy to identify the license on nuget.org and also simplifies any (semi-)automated license audits, if required