### PR TITLE
Fix: Publish NuGet Symbol Package, Enable Deterministic Builds and Source Link

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,4 +29,4 @@ jobs:
         env:
           MSBUILDSINGLELOADCONTEXT: 1
       - name: Push package to nuget
-        run: dotnet nuget push **/*.nupkg --api-key ${{secrets.NUGET_API_KEY}} --source https://api.nuget.org/v3/index.json --skip-duplicate -n
+        run: dotnet nuget push **/*.nupkg --api-key ${{secrets.NUGET_API_KEY}} --source https://api.nuget.org/v3/index.json --skip-duplicate

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: Pack nuget package
-        run: dotnet pack ./Plotly.Blazor/Plotly.Blazor.csproj --configuration Release
+        run: dotnet pack ./Plotly.Blazor/Plotly.Blazor.csproj --configuration Release /p:ContinuousIntegrationBuild=true
         env:
           MSBUILDSINGLELOADCONTEXT: 1
       - name: Push package to nuget

--- a/Plotly.Blazor/Plotly.Blazor.csproj
+++ b/Plotly.Blazor/Plotly.Blazor.csproj
@@ -35,6 +35,7 @@
         <PackageReference Include="Microsoft.AspNetCore.Components" Version="6.0.13" />
         <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="6.0.13" />
         <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
+        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="all" />
         <PackageReference Include="System.Text.Json" Version="6.0.7" />
     </ItemGroup>
     <ItemGroup>


### PR DESCRIPTION
* Enable Deterministic Builds
* Use SourceLink

See <https://learn.microsoft.com/en-us/dotnet/standard/library-guidance/sourcelink> for more information. I missed adding those two in #288 to complete the improved NuGet experience, sorry.

* Remove the `-n` flag from the publish action, that actively prevented uploading of the symbol packages we create since #288

Finally these changes look like this in [NuGet Package Explorer](https://nuget.info/packages/Plotly.Blazor/):

![image](https://user-images.githubusercontent.com/5229609/221565971-fd1e8362-8b63-4f90-b86b-cb83f7a2e5c0.png)
