### PR TITLE
Add click event to 3d charts examples

### DIFF
--- a/Plotly.Blazor.Examples/Components/Display/HoverClickDisplay.razor
+++ b/Plotly.Blazor.Examples/Components/Display/HoverClickDisplay.razor
@@ -1,0 +1,32 @@
+﻿@using Plotly.Blazor.Interop
+
+<MudGrid Spacing="2" Justify="Justify.FlexStart">
+    @if (HoverInfos != null && HoverInfos.Any())
+    {
+        @Content(HoverInfos.ToArray(), "Hover Event:")
+    }
+    @if (ClickInfos != null && ClickInfos.Any())
+    {
+        @Content(ClickInfos.ToArray(), "Click Event:")
+    }
+</MudGrid>
+
+@code
+{
+    [Parameter]
+    public IEnumerable<EventDataPoint> ClickInfos { get; set; }
+    
+    [Parameter]
+    public IEnumerable<EventDataPoint> HoverInfos { get; set; }
+
+    private RenderFragment Content(EventDataPoint[] dataPoints, string header)
+        => @<MudItem>
+                   <MudText>@header</MudText>
+                   <MudText>Current X: @dataPoints.First().X</MudText>
+                   <MudText>Current Y: @dataPoints.First().Y</MudText>
+                   @if (dataPoints.First().Z != null)
+                   {
+                    <MudText>Current z: @dataPoints.First().Z</MudText>
+                   }
+           </MudItem>;
+}

--- a/Plotly.Blazor.Examples/Components/RibbonChart.razor
+++ b/Plotly.Blazor.Examples/Components/RibbonChart.razor
@@ -3,6 +3,8 @@
 @using XAxis = Plotly.Blazor.LayoutLib.SceneLib.XAxis
 @using YAxis = Plotly.Blazor.LayoutLib.SceneLib.YAxis
 @using Newtonsoft.Json.Linq
+@using Plotly.Blazor.Interop
+@using Plotly.Blazor.Examples.Components.Display
 @inject NavigationManager MyNavigationManager
 
 @if (!IsInitialized)
@@ -12,7 +14,10 @@
     </MudPaper>
 }
 
-<PlotlyChart style="height: 60vh; min-height: 350px" @bind-Config="config" @bind-Layout="layout" @bind-Data="data" @ref="chart" AfterRender="LoadData"/>
+<PlotlyChart style="height: 60vh; min-height: 350px" @bind-Config="config" @bind-Layout="layout" @bind-Data="data" @ref="chart" 
+             ClickAction="ClickAction" HoverAction="HoverAction" AfterRender="LoadData"/>
+
+<HoverClickDisplay ClickInfos="@ClickInfos" HoverInfos="@HoverInfos"/>
 
 @code
 {
@@ -23,6 +28,8 @@
     private Config config;
     private Layout layout;
     private IList<ITrace> data;
+    private IEnumerable<EventDataPoint> ClickInfos { get; set; }
+    private IEnumerable<EventDataPoint> HoverInfos { get; set; }
 
     private bool IsInitialized { get; set; }
     const string Url = "https://raw.githubusercontent.com/plotly/datasets/master/3d-ribbon.json";
@@ -98,6 +105,26 @@
             IsInitialized = true;
             await InvokeAsync(StateHasChanged);
         });
+        
+        SubscribeEvents();
+    }
+    
+    public void ClickAction(IEnumerable<EventDataPoint> eventData)
+    {
+        ClickInfos = eventData;
+        StateHasChanged();
+    }
+    
+    public void HoverAction(IEnumerable<EventDataPoint> eventData)
+    {
+        HoverInfos = eventData;
+        StateHasChanged();
+    }
+
+    public async void SubscribeEvents()
+    {
+        await chart.SubscribeClickEvent();
+        await chart.SubscribeHoverEvent();
     }
 
     record Ribbon(object[][] X, object[][] Y, object[][] Z, string[][] ColorScale);

--- a/Plotly.Blazor.Examples/Components/SurfaceChart.razor
+++ b/Plotly.Blazor.Examples/Components/SurfaceChart.razor
@@ -1,6 +1,7 @@
 ﻿@using Plotly.Blazor.LayoutLib
 @using System.Globalization
 @using Plotly.Blazor.Interop
+@using Plotly.Blazor.Examples.Components.Display
 @inject NavigationManager MyNavigationManager
 
 @if (!IsInitialized)
@@ -10,14 +11,10 @@
     </MudPaper>
 }
 
-<PlotlyChart style="height: 60vh; min-height: 350px" @bind-Config="config" @bind-Layout="layout" @bind-Data="data" @ref="chart" HoverAction="HoverAction" AfterRender="LoadData" />
+<PlotlyChart style="height: 60vh; min-height: 350px" @bind-Config="config" @bind-Layout="layout" @bind-Data="data" @ref="chart" 
+             ClickAction="ClickAction" HoverAction="HoverAction" AfterRender="LoadData" />
 
-@if (HoverInfos != null && HoverInfos.Any())
-{
-    <MudText>Current X: @HoverInfos.First().X</MudText>
-    <MudText>Current Y: @HoverInfos.First().Y</MudText>
-    <MudText>Current Z: @HoverInfos.First().Z</MudText>
-}
+<HoverClickDisplay ClickInfos="@ClickInfos" HoverInfos="@HoverInfos"/>
 
 @code
 {
@@ -29,6 +26,7 @@
     private Layout layout;
     private IList<ITrace> data;
 
+    private IEnumerable<EventDataPoint> ClickInfos { get; set; }
     private IEnumerable<EventDataPoint> HoverInfos { get; set; }
 
     private bool IsInitialized { get; set; }
@@ -81,10 +79,17 @@
             }
             IsInitialized = true;
             await chart.SubscribeHoverEvent();
+            await chart.SubscribeClickEvent();
             await InvokeAsync(StateHasChanged);
         });
     }
 
+    public void ClickAction(IEnumerable<EventDataPoint> eventData)
+    {
+        ClickInfos = eventData;
+        StateHasChanged();
+    }
+    
     public void HoverAction(IEnumerable<EventDataPoint> eventData)
     {
         HoverInfos = eventData;


### PR DESCRIPTION
I was investigating if click and hover event work for 3d charts as I thought mentioned events have been added only for 2d charts.
As part of my tests I updated Ribbon and Surface charts examples that I have used as my test objects.
For convinient display I have added new .razor component that will display values in two columns (3d & 2d) for click and hover event using MudGrid .

I have not seen click event for legend so it is something I want to take a look at next.
Do we want any task/issue open for that? 