### PR TITLE
Add legend click event

### DIFF
--- a/Plotly.Blazor.Examples/Components/LegendClick.razor
+++ b/Plotly.Blazor.Examples/Components/LegendClick.razor
@@ -1,0 +1,76 @@
+﻿@using Plotly.Blazor.LayoutLib
+@using Plotly.Blazor.Interop
+<PlotlyChart style="height: 60vh; min-height: 350px" @bind-Config="config" @bind-Layout="layout" @bind-Data="data" @ref="chart"
+             LegendClickAction="LegendClickAction" AfterRender="SubscribeEvents"/>
+
+@if (LegendInfo != null)
+{
+    <MudText>Curve number: @LegendInfo.CurveNumber</MudText>
+    <MudText>ExpandedIndex: @LegendInfo.ExpandedIndex</MudText>
+}
+
+@code
+{
+    [CascadingParameter]
+    private MudTheme Theme { get; set; }
+
+    private PlotlyChart chart;
+    private Config config;
+    private Layout layout;
+    private IList<ITrace> data;    
+    private LegendEventDataPoint LegendInfo { get; set; }
+
+    /// <inheritdoc />
+    protected override void OnInitialized()
+    {
+        config = new Config
+        {
+            Responsive = true
+        };
+
+        layout = new Layout
+        {
+            Title = new Title
+            {
+                Text = GetType().Name
+            },
+            PaperBgColor = Theme.PaletteDark.Surface.ToString(),
+            PlotBgColor = Theme.PaletteDark.Surface.ToString(),
+            Font = new Font
+            {
+                Color = Theme.PaletteDark.TextPrimary.ToString()
+            },
+            ShowLegend = true,
+            BarMode = BarModeEnum.Stack
+        };
+        
+        data = new List<ITrace>
+        {
+            new Bar
+            {
+                X = new List<object> { "giraffes", "orangutans", "monkeys" },
+                Y = new List<object> { 20, 14, 23 },
+                Name = "SF Zoo"
+            },
+            new Bar
+            {
+                X = new List<object> { "giraffes", "orangutans", "monkeys" },
+                Y = new List<object> { 12, 18, 29 },
+                Name = "LA Zoo"
+            }
+        };
+
+        base.OnInitialized();
+    }
+    
+    public void LegendClickAction(LegendEventDataPoint eventData)
+    {
+        LegendInfo = eventData;
+        StateHasChanged();
+    }
+
+    public async void SubscribeEvents()
+    {
+        await chart.SubscribeLegendClickEvent();
+    }
+}

--- a/Plotly.Blazor.Examples/Pages/LegendClickPage.razor
+++ b/Plotly.Blazor.Examples/Pages/LegendClickPage.razor
@@ -1,0 +1,5 @@
+﻿@page "/legendclick"
+
+<Example Title="Legend Click Event" Url="Plotly.Blazor.Examples/Components/LegendClick.razor">
+    <LegendClick/>
+</Example>

--- a/Plotly.Blazor.Examples/Shared/NavMenu.razor
+++ b/Plotly.Blazor.Examples/Shared/NavMenu.razor
@@ -21,8 +21,9 @@
         <MudNavLink Match="NavLinkMatch.All" Href="@($"{NavManager.BaseUri}scattergl")">ScatterGl</MudNavLink>
         <MudNavLink Match="NavLinkMatch.All" Href="@($"{NavManager.BaseUri}indicator")">Indicator</MudNavLink>
         <MudNavLink Match="NavLinkMatch.All" Href="@($"{NavManager.BaseUri}smith")">Smith</MudNavLink>
-        <MudNavLink Match="NavLinkMatch.All" Href="@($"{NavManager.BaseUri}hover")">HoverEvent</MudNavLink>
-        <MudNavLink Match="NavLinkMatch.All" Href="@($"{NavManager.BaseUri}click")">ClickEvent</MudNavLink>
-        <MudNavLink Match="NavLinkMatch.All" Href="@($"{NavManager.BaseUri}relayout")">RelayoutEvent</MudNavLink>
+        <MudNavLink Match="NavLinkMatch.All" Href="@($"{NavManager.BaseUri}hover")">Hover Event</MudNavLink>
+        <MudNavLink Match="NavLinkMatch.All" Href="@($"{NavManager.BaseUri}click")">Click Event</MudNavLink>
+        <MudNavLink Match="NavLinkMatch.All" Href="@($"{NavManager.BaseUri}legendclick")">Legend Click Event</MudNavLink>
+        <MudNavLink Match="NavLinkMatch.All" Href="@($"{NavManager.BaseUri}relayout")">Relayout Event</MudNavLink>
     </MudNavMenu>
 </MudDrawer>

--- a/Plotly.Blazor.Generator/src/PlotlyChart.razor.cs
+++ b/Plotly.Blazor.Generator/src/PlotlyChart.razor.cs
@@ -626,6 +626,13 @@ namespace Plotly.Blazor
         }
 
         /// <summary>
+        ///     Defines the action that should happen when the LegendClickAction is triggered.
+        ///     Objects are currently required for accomodating different plot value types
+        /// </summary>
+        [Parameter]
+        public Action<LegendEventDataPoint> LegendClickAction { get; set; }
+
+        /// <summary>
         ///     Defines the action that should happen when the ClickEvent is triggered.
         ///     Objects are currently required for accomodating different plot value types
         /// </summary>
@@ -644,6 +651,17 @@ namespace Plotly.Blazor
         /// </summary>
         [Parameter]
         public Action<RelayoutEventData> RelayoutAction { get; set; }
+
+        /// <summary>
+        ///     Method which is called by JSRuntime once a plot has been clicked, to invoke the passed in ClickAction.
+        ///     Objects are currently required for accommodating different plot value types.
+        /// </summary>
+        //// <param name = "eventData"></param>
+        [JSInvokable("LegendClickEvent")]
+        public void LegendClickEvent(LegendEventDataPoint eventData)
+        {
+            LegendClickAction?.Invoke(eventData);
+        }
 
         /// <summary>
         ///     Method which is called by JSRuntime once a plot has been clicked, to invoke the passed in ClickAction.
@@ -674,6 +692,16 @@ namespace Plotly.Blazor
         public void RelayoutEvent(RelayoutEventData obj)
         {
             RelayoutAction?.Invoke(obj);
+        }
+
+        /// <summary>
+        ///     Subscribes to the legend click event of the chart.
+        /// </summary>
+        /// <param name = "cancellationToken">CancellationToken</param>
+        /// <returns>Task</returns>
+        public async Task SubscribeLegendClickEvent(CancellationToken cancellationToken = default)
+        {
+            await JsRuntime.SubscribeLegendClickEvent(objectReference, cancellationToken);
         }
 
         /// <summary>

--- a/Plotly.Blazor.Generator/src/PlotlyJsInterop.cs
+++ b/Plotly.Blazor.Generator/src/PlotlyJsInterop.cs
@@ -194,6 +194,17 @@ public static class PlotlyJsInterop
     }
 
     /// <summary>
+    ///     Can be used to subscribe click events for legend.
+    /// </summary>
+    /// <param name="jsRuntime">The js runtime.</param>
+    /// <param name="objectReference">The object reference.</param>
+    /// <param name="cancellationToken">CancellationToken</param>
+    public static async Task SubscribeLegendClickEvent(this IJSRuntime jsRuntime, DotNetObjectReference<PlotlyChart> objectReference, CancellationToken cancellationToken)
+    {
+        await jsRuntime.InvokeVoidAsync($"{PlotlyInterop}.subscribeLegendClickEvent", cancellationToken, objectReference, objectReference.Value.Id);
+    }
+
+    /// <summary>
     ///     Can be used to subscribe click events for points.
     /// </summary>
     /// <param name="jsRuntime">The js runtime.</param>

--- a/Plotly.Blazor.Generator/src/wwwroot/plotly-interop.js
+++ b/Plotly.Blazor.Generator/src/wwwroot/plotly-interop.js
@@ -59,6 +59,17 @@
     downloadImage: function (id, format, height, width, filename) {
         return window.Plotly.downloadImage(id, { format: format, height: height, width: width, filename: filename });
     },
+    subscribeLegendClickEvent: function (dotNetObj, id) {
+        var plot = document.getElementById(id);
+        plot.on('plotly_legendclick', function (data) {
+            console.log("title: " + data.layout.title.text + " curveNumber:" + data.curveNumber + " expandedIndex:" + data.expandedIndex)
+            
+            dotNetObj.invokeMethodAsync('LegendClickEvent', {
+                CurveNumber: data.curveNumber,
+                ExpandedIndex: data.expandedIndex
+            })
+        })
+    },
     subscribeClickEvent: function (dotNetObj, id) {
         var plot = document.getElementById(id);
         plot.on('plotly_click', function (data) {

--- a/Plotly.Blazor/Interop/EventDataPoint.cs
+++ b/Plotly.Blazor/Interop/EventDataPoint.cs
@@ -56,4 +56,20 @@
         /// </summary>
         public object Lon { get; set; }
     }
+    
+    /// <summary>
+    ///     A single event can have one selected point.
+    /// </summary>
+    public class LegendEventDataPoint
+    {
+        /// <summary>
+        //      The zero-based point number. Can be used to identify the trace.
+        /// </summary>
+        public object CurveNumber { get; set; }
+
+        /// <summary>
+        ///     The zero-based point number. Can be used to identify the expanded trace
+        /// </summary>
+        public object ExpandedIndex { get; set; }
+    }
 }

--- a/Plotly.Blazor/PlotlyChart.razor
+++ b/Plotly.Blazor/PlotlyChart.razor
@@ -8,4 +8,3 @@
 @implements IDisposable
 
 <div style="min-height: 350px; height: 100%" @attributes="AdditionalAttributes" id="@Id"></div>
-

--- a/Plotly.Blazor/PlotlyChart.razor.cs
+++ b/Plotly.Blazor/PlotlyChart.razor.cs
@@ -626,6 +626,13 @@ namespace Plotly.Blazor
         }
 
         /// <summary>
+        ///     Defines the action that should happen when the LegendClickAction is triggered.
+        ///     Objects are currently required for accomodating different plot value types
+        /// </summary>
+        [Parameter]
+        public Action<LegendEventDataPoint> LegendClickAction { get; set; }
+
+        /// <summary>
         ///     Defines the action that should happen when the ClickEvent is triggered.
         ///     Objects are currently required for accomodating different plot value types
         /// </summary>
@@ -644,6 +651,17 @@ namespace Plotly.Blazor
         /// </summary>
         [Parameter]
         public Action<RelayoutEventData> RelayoutAction { get; set; }
+
+        /// <summary>
+        ///     Method which is called by JSRuntime once a plot has been clicked, to invoke the passed in ClickAction.
+        ///     Objects are currently required for accommodating different plot value types.
+        /// </summary>
+        //// <param name = "eventData"></param>
+        [JSInvokable("LegendClickEvent")]
+        public void LegendClickEvent(LegendEventDataPoint eventData)
+        {
+            LegendClickAction?.Invoke(eventData);
+        }
 
         /// <summary>
         ///     Method which is called by JSRuntime once a plot has been clicked, to invoke the passed in ClickAction.
@@ -674,6 +692,16 @@ namespace Plotly.Blazor
         public void RelayoutEvent(RelayoutEventData obj)
         {
             RelayoutAction?.Invoke(obj);
+        }
+
+        /// <summary>
+        ///     Subscribes to the legend click event of the chart.
+        /// </summary>
+        /// <param name = "cancellationToken">CancellationToken</param>
+        /// <returns>Task</returns>
+        public async Task SubscribeLegendClickEvent(CancellationToken cancellationToken = default)
+        {
+            await JsRuntime.SubscribeLegendClickEvent(objectReference, cancellationToken);
         }
 
         /// <summary>

--- a/Plotly.Blazor/PlotlyJsInterop.cs
+++ b/Plotly.Blazor/PlotlyJsInterop.cs
@@ -205,6 +205,17 @@ public static class PlotlyJsInterop
     }
 
     /// <summary>
+    ///     Can be used to subscribe click events for legend.
+    /// </summary>
+    /// <param name="jsRuntime">The js runtime.</param>
+    /// <param name="objectReference">The object reference.</param>
+    /// <param name="cancellationToken">CancellationToken</param>
+    public static async Task SubscribeLegendClickEvent(this IJSRuntime jsRuntime, DotNetObjectReference<PlotlyChart> objectReference, CancellationToken cancellationToken)
+    {
+        await jsRuntime.InvokeVoidAsync($"{PlotlyInterop}.subscribeLegendClickEvent", cancellationToken, objectReference, objectReference.Value.Id);
+    }
+
+    /// <summary>
     ///     Can be used to subscribe hover events for points.
     /// </summary>
     /// <param name="jsRuntime">The js runtime.</param>

--- a/Plotly.Blazor/wwwroot/plotly-interop.js
+++ b/Plotly.Blazor/wwwroot/plotly-interop.js
@@ -59,6 +59,17 @@
     downloadImage: function (id, format, height, width, filename) {
         return window.Plotly.downloadImage(id, { format: format, height: height, width: width, filename: filename });
     },
+    subscribeLegendClickEvent: function (dotNetObj, id) {
+        var plot = document.getElementById(id);
+        plot.on('plotly_legendclick', function (data) {
+            console.log("title: " + data.layout.title.text + " curveNumber:" + data.curveNumber + " expandedIndex:" + data.expandedIndex)
+            
+           dotNetObj.invokeMethodAsync('LegendClickEvent', {
+               CurveNumber: data.curveNumber,
+               ExpandedIndex: data.expandedIndex
+           })
+        })
+    },
     subscribeClickEvent: function (dotNetObj, id) {
         var plot = document.getElementById(id);
         plot.on('plotly_click', function (data) {


### PR DESCRIPTION
I was investigating legend click event. Plotly.Blazor was not supporting this event so this PR is introducing it.
I tried to find more informations about EventData for plotly_legendclick but this website was all I could find:
https://plotly.com/javascript/plotlyjs-events/#legend-click-events

Apart from that I did print out properties that are part of this events data but it looks like it supports curveNumber and expandedIndex plus ref to layout. If you know full list of properties or know that we can return more data from this event let me know and I will add it.

Also I am getting exception regarding code snippet that it fails to get code and it fails with code 404.
Url path to snippet is right so is this because of code is not on the repo?