### PR TITLE
Make the .js loading work when the Blazor application is not served from the server root.

### DIFF
--- a/Plotly.Blazor/PlotlyJsInterop.cs
+++ b/Plotly.Blazor/PlotlyJsInterop.cs
@@ -14,7 +14,7 @@ namespace Plotly.Blazor;
 /// </summary>
 public class PlotlyJsInterop
 {
-    private const string InteropPath = "/_content/Plotly.Blazor/plotly-interop.js";
+    private const string InteropPath = "./_content/Plotly.Blazor/plotly-interop.js";
     private readonly DotNetObjectReference<PlotlyChart> dotNetObj;
     private readonly Lazy<Task<IJSObjectReference>> moduleTask;
 

--- a/Plotly.Blazor/wwwroot/plotly-interop.js
+++ b/Plotly.Blazor/wwwroot/plotly-interop.js
@@ -1,4 +1,4 @@
-﻿import '/_content/Plotly.Blazor/plotly-latest.min.js';
+﻿import './plotly-latest.min.js';
 
 export function newPlot(id, data = [], layout = {}, config = {}, frames = []) {
     window.Plotly.newPlot(id, data, layout, config, frames);


### PR DESCRIPTION
Resolves https://github.com/LayTec-AG/Plotly.Blazor/issues/418