### PR TITLE
Fixed bug in PlotlyConverter regex for subplot

### DIFF
--- a/Plotly.Blazor.Tests/ConverterTests.cs
+++ b/Plotly.Blazor.Tests/ConverterTests.cs
@@ -59,6 +59,20 @@ namespace Plotly.Blazor.Tests
 
         [Subplot]
         public IList<TestClass> Items { get; set; }
+        
+        // ensure that the regex does not match "items"
+        [JsonPropertyName("notItems")]
+        public string NotItems { get; set; }
+    }
+
+    [JsonConverter(typeof(PlotlyConverter))]
+    public class TestSubplotClass2
+    {
+        [JsonPropertyName("someItems")]
+        public string SomeItems { get; set; }
+
+        [Subplot]
+        public IList<TestClass> Items { get; set; }
     }
 
     public class TestPolymorphicClass
@@ -182,7 +196,12 @@ namespace Plotly.Blazor.Tests
                 TestProperty = "Test",
                 TestProperty2 = "Test2",
                 TestProperty3 = "Test3",
-                Items = new []{new TestClass{TestFlag = TestFlag.All}, new TestClass()},
+                Items = new []
+                {
+	                new TestClass{TestFlag = TestFlag.All}, 
+	                new TestClass()
+                },
+                NotItems = "Test4"
             };
 
             var serialized = JsonSerializer.Serialize(expected, serializerOptions);

--- a/Plotly.Blazor/PlotlyConverter.cs
+++ b/Plotly.Blazor/PlotlyConverter.cs
@@ -66,7 +66,7 @@ namespace Plotly.Blazor
                     string.Equals(p.Name, $"{propertyName}Array", StringComparison.OrdinalIgnoreCase));
 
                 var subplotProperty = subplotProperties.FirstOrDefault(p =>
-                    Regex.IsMatch(propertyName, $"{p.Name}\\d*", RegexOptions.IgnoreCase));
+                    Regex.IsMatch(propertyName, $"^{p.Name}\\d*", RegexOptions.IgnoreCase));
 
                 var otherProperty = otherProperties.FirstOrDefault(p =>
                     string.Equals(p.Name, propertyName, StringComparison.OrdinalIgnoreCase));


### PR DESCRIPTION
Fixes a bug in the `PlotlyConverter` which throws when deserializing the legend (and probably others) which occurs when a property name is the same as a subplot property name, for example: 

```json
{
  "layout" : {
    "legend" : {
      "orientation" : "h",
      "visible" : true
    }
    "showlegend" : true,
  }
}
```

the bug was in line 68:

```c#
var subplotProperty = subplotProperties.FirstOrDefault(p =>
                    Regex.IsMatch(propertyName, $"{p.Name}\\d*", RegexOptions.IgnoreCase));
```

matches "legend" and "showLegend". Since "showLegend" is not of type `IList<>` it throws. The fix was to add "^" to the regex as follows: 

```c#
var subplotProperty = subplotProperties.FirstOrDefault(p =>
                    Regex.IsMatch(propertyName, $"^{p.Name}\\d*", RegexOptions.IgnoreCase));
```

I also added the following property to the `ConverterTests` :

```c#
        [JsonPropertyName("notItems")]
        public string NotItems { get; set; }
```

and verfied that the tests now pass 

