### PR TITLE
Fix: Clear plotlyReadyCallbacks to prevent old callbacks from executing.

### DIFF
--- a/Plotly.Blazor.Generator/Plotly.Blazor.Generator.csproj
+++ b/Plotly.Blazor.Generator/Plotly.Blazor.Generator.csproj
@@ -38,7 +38,7 @@
         <None Include="..\Plotly.Blazor\wwwroot\plotly-basic-3.0.0.min.js" Link="src\wwwroot\plotly-basic-3.0.0.min.js">
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         </None>
-        <None Include="..\Plotly.Blazor\wwwroot\plotly-interop-6.0.0.js" Link="src\wwwroot\plotly-interop-6.0.0.js">
+        <None Include="..\Plotly.Blazor\wwwroot\plotly-interop-6.0.1.js" Link="src\wwwroot\plotly-interop-6.0.1.js">
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         </None>
         <None Include="..\Plotly.Blazor\_Imports.razor" Link="src\_Imports.razor">

--- a/Plotly.Blazor/PlotlyJsInterop.cs
+++ b/Plotly.Blazor/PlotlyJsInterop.cs
@@ -14,7 +14,7 @@ namespace Plotly.Blazor;
 /// </summary>
 public class PlotlyJsInterop
 {
-    private const string InteropPath = "./_content/Plotly.Blazor/plotly-interop-6.0.0.js";
+    private const string InteropPath = "./_content/Plotly.Blazor/plotly-interop-6.0.1.js";
     private const string PlotlyPath = "./_content/Plotly.Blazor/plotly-3.0.0.min.js";
     private const string PlotlyBasicPath = "./_content/Plotly.Blazor/plotly-basic-3.0.0.min.js";
 

--- a/Plotly.Blazor/wwwroot/plotly-interop-6.0.1.js
+++ b/Plotly.Blazor/wwwroot/plotly-interop-6.0.1.js
@@ -30,6 +30,7 @@ export async function importScript(id, scriptUrl) {
             scriptCache.set(id, scriptUrl);
             plotlyReady = true;
             plotlyReadyCallbacks.forEach(callback => callback());
+            plotlyReadyCallbacks.length = 0;
             resolve();
         };
         script.onerror = (error) => {


### PR DESCRIPTION
This is a fix for issue #470. If using more than one chart on a page in a fast loading environment, such as a production environment, charts might fail to render on subsequent visits to the page.

Possible timeline:

First page visit:

Chart-1: Plotly might not be loaded -> calls end up in plotlyReadyCallback queue.
script.onload is fired, executing Chart1 callbacks and renders Chart-1.
Chart-2 is rendered directly since Plotly is loaded, which means no callbacks in queue.

Second page visit:

Chart-3: Since plotly is already loaded renders directly with no callbacks in queue.
script.onload is fired trying to execute callbacks for Chart-1 which does not exist and causes an uncaught exception.
Chart-4 is not rendered due to uncaught errors.

Note that the exceptions can still be thrown even with one plot on the page but mostly the chart is already rendered when the exception is thrown. 

